### PR TITLE
Polish journal UI and add performance insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ pnpm dev
 
 Requirements: Node 22+, pnpm. First run creates the SQLite database by itself. No migration tool, no setup wizard, no account.
 
+For smooth everyday use or UI reviews, stop the development server and run `pnpm preview`.
+This builds the app once, then serves the optimized production version at the same address,
+using the same local data. Unlike `pnpm dev`, it does not compile each page on its first
+visit or hot-reload code edits. After code changes, stop it and rerun `pnpm preview` to
+rebuild; use `pnpm start` to reuse an existing build. Switch back to `pnpm dev` when editing.
+Run only one mode at a time, since development and production share the build directory.
+
 ### Docker
 
 ```bash

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -38,6 +38,7 @@
     "next": "^15.5.0",
     "pdf-lib": "^1.17.1",
     "react": "^19.1.0",
+    "react-day-picker": "^9.14.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
     "recharts": "^3.10.1",

--- a/apps/web/src/app/api/calendar/route.ts
+++ b/apps/web/src/app/api/calendar/route.ts
@@ -1,0 +1,51 @@
+import { calendarMonthFromDays, dailyStats, dayKeyOf, readFilters } from "@luxalgo/journal-core";
+import { accounts, db } from "@/db";
+import { handler, ok, requireValue } from "@/server/api";
+import { getTimeZone } from "@/server/settings";
+import { queryTrades } from "@/server/trades-query";
+import { calendarInsights, calendarScope } from "@/lib/calendar-insights";
+
+/** Only compute the visible month, not every dashboard/report breakdown. */
+export const GET = handler(async (request: Request) => {
+  const params = new URL(request.url).searchParams;
+  const timeZone = getTimeZone();
+  const today = dayKeyOf(new Date().toISOString(), timeZone);
+  const year = Number(params.get("calYear") ?? today.slice(0, 4));
+  const month = Number(params.get("calMonth") ?? today.slice(5, 7));
+  requireValue(
+    Number.isInteger(year) &&
+      year >= 1900 &&
+      year <= 9999 &&
+      Number.isInteger(month) &&
+      month >= 1 &&
+      month <= 12,
+    "Choose a valid calendar month.",
+  );
+  const scope = calendarScope(readFilters(params), year, month);
+  const { trades } = queryTrades(scope);
+  const calendar = calendarMonthFromDays(dailyStats(trades, timeZone), year, month);
+  const accountRows = db
+    .select({ id: accounts.id, currency: accounts.currency })
+    .from(accounts)
+    .all();
+  const currencyByAccount = new Map(accountRows.map((account) => [account.id, account.currency]));
+  const currencies = [
+    ...new Set(
+      trades
+        .filter((trade) => trade.status !== "open" && trade.closedAt)
+        .map((trade) => currencyByAccount.get(trade.accountId) ?? "USD"),
+    ),
+  ].sort();
+  if (!currencies.length) {
+    const selectedIds = scope.accounts?.split(",").map((id) => id.trim());
+    currencies.push(
+      ...new Set(
+        accountRows
+          .filter((account) => !selectedIds || selectedIds.includes(account.id))
+          .map((account) => account.currency),
+      ),
+    );
+    currencies.sort();
+  }
+  return ok({ calendar, insights: calendarInsights(calendar), timeZone, currencies, scope });
+});

--- a/apps/web/src/app/api/performance-trends/route.ts
+++ b/apps/web/src/app/api/performance-trends/route.ts
@@ -1,0 +1,28 @@
+import { readFilters } from "@luxalgo/journal-core";
+import { accounts, db } from "@/db";
+import { performanceTrends } from "@/lib/performance-trends";
+import { handler, ok } from "@/server/api";
+import { getTimeZone } from "@/server/settings";
+import { queryTrades } from "@/server/trades-query";
+
+export const GET = handler((request: Request) => {
+  const { trades } = queryTrades(readFilters(new URL(request.url).searchParams));
+  const currencies = new Map(
+    db
+      .select({ id: accounts.id, currency: accounts.currency })
+      .from(accounts)
+      .all()
+      .map((account) => [account.id, account.currency]),
+  );
+  return ok({
+    trends: performanceTrends(trades),
+    currencies: [
+      ...new Set(
+        trades
+          .filter((trade) => trade.status !== "open" && trade.closedAt)
+          .map((trade) => currencies.get(trade.accountId) ?? "USD"),
+      ),
+    ],
+    timeZone: getTimeZone(),
+  });
+});

--- a/apps/web/src/app/api/trade-explorer/route.ts
+++ b/apps/web/src/app/api/trade-explorer/route.ts
@@ -1,0 +1,29 @@
+import { readFilters } from "@luxalgo/journal-core";
+import { accounts, db } from "@/db";
+import { tradeExplorerPoints } from "@/lib/trade-explorer";
+import { handler, ok } from "@/server/api";
+import { getTimeZone } from "@/server/settings";
+import { queryTrades } from "@/server/trades-query";
+
+export const GET = handler((request: Request) => {
+  const { trades } = queryTrades(readFilters(new URL(request.url).searchParams));
+  const timeZone = getTimeZone();
+  const currencies = new Map(
+    db
+      .select({ id: accounts.id, currency: accounts.currency })
+      .from(accounts)
+      .all()
+      .map((account) => [account.id, account.currency]),
+  );
+  return ok({
+    points: tradeExplorerPoints(trades, timeZone),
+    currencies: [
+      ...new Set(
+        trades
+          .filter((trade) => trade.status !== "open" && trade.closedAt)
+          .map((trade) => currencies.get(trade.accountId) ?? "USD"),
+      ),
+    ],
+    timeZone,
+  });
+});

--- a/apps/web/src/app/calendar/page.tsx
+++ b/apps/web/src/app/calendar/page.tsx
@@ -2,29 +2,34 @@
 
 import { Suspense, useState } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
-import type { CalendarMonth, TradeMetrics } from "@luxalgo/journal-core";
+import { dayKeyOf } from "@luxalgo/journal-core";
 import { CalendarPnl } from "@/components/calendar-pnl";
 import { FilterBar, useFilters } from "@/components/filter-bar";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useApi } from "@/lib/use-api";
+import { CalendarPerformance } from "@/components/calendar-insights";
+import type { CalendarResponse } from "@/lib/calendar-insights";
+import Loading from "@/app/loading";
 
 export default function CalendarPage() {
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <CalendarView />
     </Suspense>
   );
 }
 
 function CalendarView() {
-  const { query } = useFilters();
-  const now = new Date();
-  const [month, setMonth] = useState({ year: now.getUTCFullYear(), month: now.getUTCMonth() + 1 });
-  const { data } = useApi<{ calendar: CalendarMonth; metrics: TradeMetrics }>(
-    `/api/stats?${query}&calYear=${month.year}&calMonth=${month.month}`,
+  const { query, timeZone } = useFilters();
+  const [selection, setMonth] = useState<{ year: number; month: number } | null>(null);
+  const { data, error, refresh } = useApi<CalendarResponse>(
+    `/api/calendar?${query}${selection ? `&calYear=${selection.year}&calMonth=${selection.month}` : ""}`,
   );
+  const today = dayKeyOf(new Date().toISOString(), timeZone);
+  const month = selection ??
+    data?.calendar ?? { year: Number(today.slice(0, 4)), month: Number(today.slice(5, 7)) };
 
   const shift = (delta: number) => {
     const next = new Date(Date.UTC(month.year, month.month - 1 + delta, 1));
@@ -65,12 +70,47 @@ function CalendarView() {
           </div>
         }
       />
-      <div className="p-4">
+      <div className="space-y-4 p-4">
         <Card>
           <CardContent className="pt-4">
-            {data ? <CalendarPnl calendar={data.calendar} /> : <Skeleton className="h-96" />}
+            {error ? (
+              <div role="alert" className="space-y-3 py-6 text-sm">
+                <p className="text-destructive">{error}</p>
+                <Button variant="outline" onClick={refresh}>
+                  Try again
+                </Button>
+              </div>
+            ) : data ? (
+              <CalendarPnl
+                calendar={data.calendar}
+                currency={data.currencies[0] ?? "USD"}
+                monetary={data.currencies.length <= 1}
+              />
+            ) : (
+              <div role="status" aria-label="Loading calendar">
+                <Skeleton className="h-96" />
+              </div>
+            )}
           </CardContent>
         </Card>
+        {data && (
+          <CalendarPerformance
+            key={`${data.calendar.year}-${data.calendar.month}-${query}`}
+            data={data}
+            query={query}
+          />
+        )}
+        {!data && !error && (
+          <div
+            role="status"
+            aria-label="Loading performance insights"
+            className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4"
+          >
+            {[0, 1, 2, 3].map((index) => (
+              <Skeleton key={index} className="h-28" />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -9,6 +9,7 @@
  * win/loss ships as text chips, markers differ by shape — color only reinforces.
  */
 :root {
+  color-scheme: light;
   --background: #f9f9f7;
   --foreground: #0b0b0b;
   --card: #fcfcfb;
@@ -38,7 +39,7 @@
 
   /* viz tokens (validated: see docs/design.md) */
   --viz-surface: #fcfcfb;
-  --ink-muted: #898781;
+  --ink-muted: #686760;
   --gridline: #e1e0d9;
   --baseline: #c3c2b7;
   --profit: #006300;
@@ -56,6 +57,7 @@
 }
 
 .dark {
+  color-scheme: dark;
   --background: #08080a;
   --foreground: #f4f4f4;
   --card: #101013;
@@ -145,16 +147,13 @@
   font-variant-numeric: tabular-nums;
 }
 
-/* Prism gradient, decorative only: hero numbers and small indicator bars.
+/* Prism gradient, decorative only: hero numbers.
  * The value it decorates is always also plain text or geometry. */
 .prism-text {
   background-image: linear-gradient(100deg, var(--prism-from), var(--prism-to));
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
-}
-.prism-bar {
-  background-image: linear-gradient(180deg, var(--prism-from), var(--prism-to));
 }
 
 /* Hairline top sheen that lifts cards off a near-black canvas. */
@@ -171,8 +170,234 @@
 .journal-main {
   container: journal / inline-size;
 }
+.journal-hover-card {
+  box-shadow:
+    0 12px 32px rgb(0 0 0 / 0.18),
+    0 2px 8px rgb(0 0 0 / 0.1);
+  transform-origin: var(--radix-tooltip-content-transform-origin);
+  overflow-wrap: anywhere;
+}
+.journal-hover-card[data-state="delayed-open"],
+.journal-hover-card[data-state="instant-open"] {
+  animation: journal-hover-in 160ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.journal-hover-card[data-state="closed"] {
+  animation: journal-hover-out 100ms ease-in;
+}
+.recharts-default-tooltip .recharts-tooltip-label {
+  color: var(--muted-foreground) !important;
+  font-size: 12px;
+  margin-bottom: 4px !important;
+}
+.recharts-default-tooltip .recharts-tooltip-item {
+  color: var(--foreground) !important;
+  font-variant-numeric: tabular-nums;
+}
+body.dashboard-is-dragging .journal-hover-card {
+  visibility: hidden;
+}
+@keyframes journal-hover-in {
+  from {
+    opacity: 0;
+    transform: translateY(2px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@keyframes journal-hover-out {
+  to {
+    opacity: 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .journal-hover-card {
+    animation: none !important;
+  }
+}
+.journal-chart-frame {
+  position: relative;
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  isolation: isolate;
+}
+.journal-chart-frame .recharts-surface {
+  overflow: hidden;
+}
+.journal-edge-radar :focus {
+  outline: none;
+}
+.journal-edge-radar:has(:focus-visible) {
+  outline: 2px solid var(--ring);
+  outline-offset: -3px;
+  border-radius: 6px;
+}
+.journal-chart-frame .recharts-tooltip-wrapper {
+  max-width: 100%;
+  white-space: normal;
+}
+.journal-chart-frame .recharts-area,
+.journal-chart-frame .recharts-bar,
+.journal-chart-frame .recharts-radar,
+.journal-gauge-value,
+.journal-progress-visual {
+  animation: journal-data-reveal 850ms cubic-bezier(0.25, 0.1, 0.25, 1) backwards;
+}
+.journal-gauge svg {
+  max-width: 100%;
+}
+/* Animate plotted data only; report content, controls, axes and grids stay still. */
+.journal-report-section .recharts-line-curve {
+  animation: journal-data-reveal 850ms cubic-bezier(0.25, 0.1, 0.25, 1) backwards;
+}
+.journal-report-section .recharts-scatter-symbol {
+  animation: journal-scatter-reveal 850ms ease-out backwards;
+}
+@keyframes journal-scatter-reveal {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .journal-report-section .recharts-line-curve,
+  .journal-report-section .recharts-scatter-symbol {
+    animation: none !important;
+  }
+}
+@keyframes journal-data-reveal {
+  from {
+    opacity: 0;
+    clip-path: inset(0 100% 0 0);
+  }
+  to {
+    opacity: 1;
+    clip-path: inset(0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .journal-chart-frame *,
+  .journal-gauge-value,
+  .journal-progress-visual {
+    animation: none !important;
+  }
+}
 .journal-desktop-sidebar {
   view-transition-name: journal-sidebar;
+  z-index: 40;
+  width: 13rem;
+  transition: width 280ms cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: width;
+}
+.journal-desktop-sidebar[data-ready="false"] {
+  transition: none;
+}
+.journal-desktop-sidebar[data-collapsed="true"] {
+  width: 4rem;
+}
+.journal-sidebar-home {
+  width: 100%;
+  overflow: hidden;
+  padding-inline: 1rem;
+  transition: padding 280ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.journal-sidebar-brand-label,
+.journal-sidebar-label {
+  max-width: 9.5rem;
+  overflow: hidden;
+  white-space: nowrap;
+  opacity: 1;
+  transform: translateX(0);
+  transition:
+    max-width 240ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 160ms ease-out,
+    transform 240ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.journal-sidebar-trigger {
+  right: 0;
+  top: 50%;
+  z-index: 10;
+  transform: translate(50%, -50%);
+  transition:
+    color 160ms ease,
+    background-color 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.journal-sidebar-trigger:hover {
+  transform: translate(50%, -50%) scale(1.06);
+}
+.journal-sidebar-nav-link > svg {
+  flex: 0 0 auto;
+}
+.journal-sidebar-nav-link {
+  min-height: 2.25rem;
+  transition:
+    padding 240ms cubic-bezier(0.22, 1, 0.36, 1),
+    gap 240ms cubic-bezier(0.22, 1, 0.36, 1),
+    color 160ms ease,
+    background-color 160ms ease;
+}
+.journal-sidebar-footer {
+  max-height: 5rem;
+  overflow: hidden;
+  opacity: 1;
+  transition:
+    max-height 220ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 140ms ease-out,
+    padding 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.journal-sidebar-privacy {
+  display: flex;
+  justify-content: center;
+  transition: padding 240ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.journal-desktop-sidebar[data-collapsed="true"] .journal-sidebar-home {
+  justify-content: center;
+  padding-inline: 0;
+}
+.journal-desktop-sidebar[data-collapsed="true"] .journal-sidebar-brand-label,
+.journal-desktop-sidebar[data-collapsed="true"] .journal-sidebar-label {
+  max-width: 0;
+  opacity: 0;
+  transform: translateX(-0.35rem);
+}
+.journal-desktop-sidebar[data-collapsed="true"] .journal-sidebar-navigation {
+  padding-inline: 0.625rem;
+}
+.journal-desktop-sidebar[data-collapsed="true"] .journal-sidebar-nav-link {
+  justify-content: center;
+  gap: 0;
+  padding-inline: 0;
+}
+.journal-desktop-sidebar[data-collapsed="true"] .journal-sidebar-privacy {
+  padding-inline: 0;
+}
+.journal-desktop-sidebar[data-collapsed="true"] .journal-sidebar-privacy > div {
+  width: auto;
+}
+.journal-desktop-sidebar[data-collapsed="true"] .journal-sidebar-footer {
+  max-height: 0;
+  padding-block: 0;
+  opacity: 0;
+  visibility: hidden;
+}
+@media (prefers-reduced-motion: reduce) {
+  .journal-desktop-sidebar,
+  .journal-sidebar-home,
+  .journal-sidebar-brand-label,
+  .journal-sidebar-label,
+  .journal-sidebar-trigger,
+  .journal-sidebar-nav-link,
+  .journal-sidebar-footer,
+  .journal-sidebar-privacy {
+    transition: none !important;
+  }
 }
 .journal-mobile-header {
   view-transition-name: journal-header;
@@ -197,6 +422,155 @@
 }
 .journal-filter-bar {
   top: var(--journal-header-offset, 0px);
+}
+.journal-filter-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 0;
+  overflow: hidden;
+  max-height: min(90dvh, 900px);
+  border-radius: 14px;
+  box-shadow:
+    0 24px 80px rgb(0 0 0 / 0.28),
+    0 4px 16px rgb(0 0 0 / 0.12);
+}
+.journal-filter-heading {
+  flex-shrink: 0;
+  gap: 6px;
+  padding: 24px 24px 20px;
+  border-bottom: 1px solid var(--border);
+}
+.journal-filter-description {
+  max-width: 66ch;
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.65;
+}
+.journal-filter-body {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 20px 24px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+.journal-filter-footer {
+  flex-shrink: 0;
+  padding: 16px 24px;
+  border-top: 1px solid var(--border);
+  background: color-mix(in srgb, var(--muted) 35%, var(--card));
+}
+.journal-filter-footer button {
+  border-radius: 8px;
+}
+.journal-filter-fields .journal-filter-field {
+  gap: 7px;
+  line-height: 1.4;
+  font-weight: 500;
+}
+.journal-filter-fields input:not([type="checkbox"]),
+.journal-filter-fields [role="combobox"] {
+  height: 38px;
+  padding-inline: 11px;
+  border-radius: 7px;
+  border-color: var(--input);
+  background-color: color-mix(in srgb, var(--background) 65%, var(--card));
+  color: var(--foreground);
+  font-size: 13px;
+  font-weight: 400;
+  outline: none;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease,
+    background-color 150ms ease;
+  color-scheme: light;
+}
+.dark .journal-filter-fields input,
+.dark .journal-filter-fields [role="combobox"] {
+  color-scheme: dark;
+}
+.journal-filter-fields input.journal-date-input {
+  padding-right: 40px;
+}
+.journal-filter-fields input:not([type="checkbox"]):hover,
+.journal-filter-fields [role="combobox"]:hover {
+  border-color: color-mix(in srgb, var(--muted-foreground) 40%, var(--border));
+}
+.journal-filter-fields input:not([type="checkbox"]):focus-visible,
+.journal-filter-fields [role="combobox"]:focus-visible {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ring) 16%, transparent);
+}
+.journal-filter-accounts legend {
+  padding-inline: 6px;
+  font-weight: 500;
+}
+.journal-filter-choice {
+  min-height: 32px;
+  max-width: 100%;
+  padding: 5px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+  transition: background-color 150ms ease;
+}
+.journal-filter-choice:hover {
+  background: var(--accent);
+}
+.journal-filter-choice:has([data-state="checked"]) {
+  background: color-mix(in srgb, var(--brand) 10%, transparent);
+}
+.journal-filter-advanced {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.journal-filter-advanced summary {
+  padding: 12px;
+  border-radius: 8px;
+  list-style: none;
+  font-size: 13px;
+  font-weight: 500;
+  transition: background-color 150ms ease;
+}
+.journal-filter-advanced summary::-webkit-details-marker {
+  display: none;
+}
+.journal-filter-advanced summary:hover {
+  background: var(--accent);
+}
+.journal-filter-advanced summary:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
+}
+.journal-filter-advanced summary svg {
+  transition: transform 180ms ease;
+}
+.journal-filter-advanced[open] summary svg {
+  transform: rotate(180deg);
+}
+.journal-filter-advanced-grid,
+.journal-filter-weekdays {
+  margin: 0;
+  padding: 0 12px 12px;
+}
+@media (max-width: 479px) {
+  .journal-filter-heading {
+    padding: 20px 16px 16px;
+  }
+  .journal-filter-body {
+    padding: 16px;
+  }
+  .journal-filter-footer {
+    padding: 12px 16px;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .journal-filter-dialog,
+  .journal-filter-fields * {
+    animation: none !important;
+    transition: none !important;
+  }
 }
 .journal-header-actions > .flex {
   flex-wrap: wrap;
@@ -310,41 +684,37 @@
   .dashboard-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
-  .dashboard-grid-card:not([data-card-size="small"]) {
-    grid-column: span 2;
+  .dashboard-grid-card {
+    grid-column: span var(--dashboard-span-compact, 1);
   }
 }
-@container dashboard (min-width: 760px) {
+@container dashboard (min-width: 960px) {
   .dashboard-grid {
     grid-template-columns: repeat(6, minmax(0, 1fr));
   }
-  .dashboard-grid-card[data-card-size="small"] {
-    grid-column: span 2;
-  }
-  .dashboard-grid-card[data-card-size="medium"] {
-    grid-column: span 3;
-  }
-  .dashboard-grid-card[data-card-size="wide"],
-  .dashboard-grid-card[data-card-size="full"] {
-    grid-column: span 6;
+  .dashboard-grid-card {
+    grid-column: span var(--dashboard-span-tablet, 6);
   }
 }
 @container dashboard (min-width: 1060px) {
   .dashboard-grid {
     grid-template-columns: repeat(15, minmax(0, 1fr));
   }
-  .dashboard-grid-card[data-card-size="small"] {
-    grid-column: span 3;
+  .dashboard-grid-card {
+    grid-column: span var(--dashboard-span-desktop, 15);
   }
-  .dashboard-grid-card[data-card-size="medium"] {
-    grid-column: span 5;
-  }
-  .dashboard-grid-card[data-card-size="wide"] {
-    grid-column: span 10;
-  }
-  .dashboard-grid-card[data-card-size="full"] {
-    grid-column: span 15;
-  }
+}
+
+/* Visual cards consume the row height rather than leaving blank card interiors. */
+.dashboard-visual-card {
+  display: flex;
+  flex-direction: column;
+}
+.dashboard-visual-card-content {
+  display: flex;
+  min-height: 18rem;
+  flex: 1;
+  flex-direction: column;
 }
 .dashboard-layout-option:hover,
 .dashboard-layout-option:focus-visible {
@@ -359,7 +729,7 @@
   border-top: 1px solid var(--border);
 }
 
-/* A compact calendar keeps all seven days visible; weekly totals get their own row. */
+/* The compact calendar keeps all seven days visible; weekly totals get their own row. */
 .journal-calendar {
   container: calendar / inline-size;
 }
@@ -370,6 +740,27 @@
   min-height: 64px;
   padding: 4px 2px;
   font-size: clamp(8px, 2.8cqi, 11px);
+}
+.journal-calendar-day-link {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease,
+    outline-color 160ms ease;
+}
+.journal-calendar-day-link[data-performance="profit"] {
+  --calendar-outline: var(--profit);
+}
+.journal-calendar-day-link[data-performance="loss"] {
+  --calendar-outline: var(--loss);
+}
+.journal-calendar-day-link[data-performance="neutral"] {
+  --calendar-outline: var(--muted-foreground);
+}
+.journal-calendar-day-link:hover,
+.journal-calendar-day-link:focus-visible {
+  outline-color: var(--calendar-outline);
 }
 .journal-calendar-day > :first-child {
   margin-bottom: 4px;
@@ -418,6 +809,61 @@
     gap: 0;
     margin-bottom: 0;
   }
+}
+
+/* One quiet surface for date, selection, and action menus. */
+.journal-menu-surface {
+  border-color: color-mix(in srgb, var(--foreground) 7%, var(--border));
+  box-shadow:
+    0 12px 36px rgb(0 0 0 / 0.18),
+    0 3px 8px rgb(0 0 0 / 0.08),
+    inset 0 1px 0 color-mix(in srgb, var(--foreground) 4%, transparent);
+}
+.journal-calendar-nav {
+  display: inline-flex;
+  width: 32px;
+  height: 36px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 7px;
+  color: var(--muted-foreground);
+}
+.journal-calendar-nav:hover {
+  background: var(--accent);
+  color: var(--foreground);
+}
+.journal-calendar-date {
+  display: inline-flex;
+  width: 100%;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 7px;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  outline: none;
+}
+.journal-calendar-date:hover:not(:disabled) {
+  background: var(--accent);
+}
+.journal-date-outside {
+  color: var(--muted-foreground);
+  opacity: 0.55;
+}
+.journal-date-today:not(.journal-date-selected) .journal-calendar-date {
+  box-shadow: inset 0 0 0 1px var(--border);
+  font-weight: 600;
+}
+.journal-date-selected .journal-calendar-date,
+.journal-date-selected .journal-calendar-date:hover:not(:disabled) {
+  background: var(--primary);
+  color: var(--primary-foreground);
+  font-weight: 600;
+}
+.journal-calendar-date:focus-visible,
+.journal-calendar-nav:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 1px;
 }
 
 /* Notes keep the editor mounted when resizing, so unsaved typing is preserved. */
@@ -546,11 +992,11 @@
   transform-origin: var(--radix-popover-content-transform-origin);
 }
 .dashboard-customize-panel[data-state="open"] {
-  animation: dashboard-customize-open 420ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: journal-overlay-in 160ms ease-out backwards;
 }
 .dashboard-customize-panel[data-state="closed"] {
   pointer-events: none;
-  animation: dashboard-customize-close 190ms cubic-bezier(0.4, 0, 1, 1) both;
+  animation: journal-overlay-out 110ms ease-in forwards;
 }
 .dashboard-customize-heading {
   display: flex;
@@ -654,10 +1100,6 @@
   text-align: left;
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
-}
-.dashboard-customize-panel[data-state="open"] .dashboard-customize-option {
-  animation: dashboard-customize-row 340ms cubic-bezier(0.22, 1, 0.36, 1) both;
-  animation-delay: calc(60ms + var(--option-index, 0) * 22ms);
 }
 .dashboard-customize-card-icon {
   display: inline-flex;
@@ -769,45 +1211,28 @@
   outline: 2px solid var(--brand);
   outline-offset: -2px;
 }
-@keyframes dashboard-customize-open {
-  0% {
-    opacity: 0;
-    transform: translateY(-9px) scale(0.78, 0.56);
-    border-radius: 32px;
-    filter: blur(5px);
-  }
-  65% {
-    opacity: 1;
-    transform: translateY(1px) scale(1.015, 1.01);
-    filter: blur(0);
-  }
-  100% {
-    opacity: 1;
-    transform: none;
-    border-radius: 20px;
-    filter: blur(0);
-  }
+.journal-popup[data-state="open"] {
+  animation: journal-overlay-in 160ms ease-out backwards;
 }
-@keyframes dashboard-customize-close {
-  to {
-    opacity: 0;
-    transform: translateY(-7px) scale(0.93, 0.88);
-    filter: blur(3px);
-  }
+.journal-popup[data-state="closed"] {
+  pointer-events: none;
+  animation: journal-overlay-out 110ms ease-in forwards;
 }
-@keyframes dashboard-customize-row {
+@keyframes journal-overlay-in {
   from {
     opacity: 0;
-    transform: translateY(7px);
-    filter: blur(4px);
   }
   to {
     opacity: 1;
-    transform: none;
-    filter: blur(0);
+  }
+}
+@keyframes journal-overlay-out {
+  to {
+    opacity: 0;
   }
 }
 @media (prefers-reduced-motion: reduce) {
+  .journal-popup,
   .dashboard-customize-panel,
   .dashboard-customize-panel *,
   .dashboard-customize-chevron {

--- a/apps/web/src/app/journal/[date]/page.tsx
+++ b/apps/web/src/app/journal/[date]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { AiNotice } from "@/components/ai-notice";
 
 import Link from "next/link";
 import { Suspense, use, useEffect, useRef, useState } from "react";
@@ -56,6 +57,7 @@ function JournalDay({ date }: { date: string }) {
   const noteEditor = useRef<RichEditorHandle>(null);
   const { save, status: saving, flush } = useAutosave(`/api/journal/${date}`, "PUT");
   const [aiBusy, setAiBusy] = useState(false);
+  const [aiError, setAiError] = useState<string | null>(null);
   const noteValue = note ?? data?.note ?? "";
   const scheduleSave = (value: string) => {
     setNote(value);
@@ -64,12 +66,13 @@ function JournalDay({ date }: { date: string }) {
 
   const generateRecap = async () => {
     setAiBusy(true);
+    setAiError(null);
     try {
       const result = await postJson<{ recap: string }>(`/api/ai/recap`, { date });
       const merged = noteValue ? `${noteValue}\n\n---\n\n${result.recap}` : result.recap;
       scheduleSave(merged);
     } catch (error) {
-      alert(error instanceof Error ? error.message : "AI recap failed");
+      setAiError(error instanceof Error ? error.message : "AI recap failed");
     } finally {
       setAiBusy(false);
     }
@@ -214,6 +217,15 @@ function JournalDay({ date }: { date: string }) {
             </div>
           </CardHeader>
           <CardContent>
+            {aiError && (
+              <div className="mb-4">
+                <AiNotice
+                  error={aiError}
+                  onRetry={() => void generateRecap()}
+                  onDismiss={() => setAiError(null)}
+                />
+              </div>
+            )}
             {data ? (
               <RichEditor editorRef={noteEditor} value={noteValue} onChange={scheduleSave} />
             ) : error ? (

--- a/apps/web/src/app/journal/page.tsx
+++ b/apps/web/src/app/journal/page.tsx
@@ -2,13 +2,15 @@
 
 import Link from "next/link";
 import { dayKeyOf } from "@luxalgo/journal-core";
-import { Suspense } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { NotebookPen } from "lucide-react";
 import type { DayStats } from "@luxalgo/journal-core";
 import { FilterBar, useFilters } from "@/components/filter-bar";
 import { Pnl } from "@/components/pnl";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import Loading from "@/app/loading";
 import { useApi } from "@/lib/use-api";
 import { fmtPercent } from "@/lib/utils";
 
@@ -19,9 +21,15 @@ interface JournalDay {
   notePreview: string;
 }
 
+const PAGE_SIZE = 50;
+const weekdayFormatter = new Intl.DateTimeFormat("en-US", {
+  weekday: "long",
+  timeZone: "UTC",
+});
+
 export default function JournalPage() {
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <Journal />
     </Suspense>
   );
@@ -29,7 +37,12 @@ export default function JournalPage() {
 
 function Journal() {
   const { query, timeZone } = useFilters();
-  const { data } = useApi<{ days: JournalDay[] }>(`/api/journal?${query}`);
+  const { data, error, refresh } = useApi<{ days: JournalDay[] }>(`/api/journal?${query}`);
+  // Reset the visible window immediately when filters change. Keep every day
+  // available without mounting years of cards on the first render.
+  const [visibleWindow, setVisibleWindow] = useState({ query, limit: PAGE_SIZE });
+  const limit = visibleWindow.query === query ? visibleWindow.limit : PAGE_SIZE;
+  useEffect(() => setVisibleWindow({ query, limit: PAGE_SIZE }), [query]);
 
   return (
     <div>
@@ -45,23 +58,31 @@ function Journal() {
         }
       />
       <div className="space-y-2 p-4">
-        {!data && <Skeleton className="h-48" />}
+        {error ? (
+          <div role="alert" className="space-y-2 text-sm text-destructive">
+            <p>{error}</p>
+            <Button variant="outline" onClick={refresh}>
+              Try again
+            </Button>
+          </div>
+        ) : !data ? (
+          <div role="status" aria-label="Loading journal">
+            <Skeleton className="h-48" />
+          </div>
+        ) : null}
         {data?.days.length === 0 && (
           <p className="py-16 text-center text-sm text-muted-foreground">
             No trading days yet — import trades or write your first day note.
           </p>
         )}
-        {data?.days.map((day) => (
+        {data?.days.slice(0, limit).map((day) => (
           <Link key={day.date} href={`/journal/${day.date}?${query}`} className="block">
             <Card className="transition-colors hover:border-ring">
               <CardContent className="flex flex-wrap items-center gap-x-4 gap-y-3 py-3">
                 <div className="w-full shrink-0 sm:w-28">
                   <div className="text-sm font-medium">{day.date}</div>
                   <div className="text-xs text-muted-foreground">
-                    {new Date(`${day.date}T00:00:00Z`).toLocaleDateString("en-US", {
-                      weekday: "long",
-                      timeZone: "UTC",
-                    })}
+                    {weekdayFormatter.format(new Date(`${day.date}T00:00:00Z`))}
                   </div>
                 </div>
                 {day.stats ? (
@@ -94,6 +115,22 @@ function Journal() {
             </Card>
           </Link>
         ))}
+        {data && data.days.length > PAGE_SIZE && (
+          <div className="flex flex-wrap items-center justify-between gap-3 py-2 text-xs text-muted-foreground">
+            <span role="status">
+              Showing {Math.min(limit, data.days.length)} of {data.days.length} days
+            </span>
+            {limit < data.days.length && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setVisibleWindow({ query, limit: limit + PAGE_SIZE })}
+              >
+                Show older days
+              </Button>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,6 +3,9 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { Shell } from "@/components/shell";
 import { PrivacyProvider } from "@/components/privacy";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { ThemeProvider } from "@/components/theme";
+import { THEME_INIT_SCRIPT } from "@/lib/theme";
 
 export const metadata: Metadata = {
   title: "Trade Journal",
@@ -13,12 +16,19 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className="dark" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
+      </head>
       <body className="min-h-screen font-sans antialiased">
-        <Suspense>
-          <PrivacyProvider>
-            <Shell>{children}</Shell>
-          </PrivacyProvider>
-        </Suspense>
+        <TooltipProvider delayDuration={350} skipDelayDuration={150}>
+          <Suspense>
+            <ThemeProvider>
+              <PrivacyProvider>
+                <Shell>{children}</Shell>
+              </PrivacyProvider>
+            </ThemeProvider>
+          </Suspense>
+        </TooltipProvider>
       </body>
     </html>
   );

--- a/apps/web/src/app/loading.tsx
+++ b/apps/web/src/app/loading.tsx
@@ -1,0 +1,14 @@
+/** Immediate feedback while Next loads a destination route. */
+export default function Loading() {
+  return (
+    <div role="status" className="space-y-4 p-4" aria-label="Loading page">
+      <span className="sr-only">Loading page…</span>
+      <div aria-hidden="true" className="h-6 w-32 rounded-md bg-muted" />
+      <div aria-hidden="true" className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {[0, 1, 2].map((item) => (
+          <div key={item} className="h-32 rounded-xl border bg-card" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/missed/page.tsx
+++ b/apps/web/src/app/missed/page.tsx
@@ -1,4 +1,7 @@
 "use client";
+import { OptionSelect } from "@/components/ui/option-select";
+import { Checkbox } from "@/components/ui/checkbox";
+
 import { Suspense, useState } from "react";
 import { FilterBar } from "@/components/filter-bar";
 import { Field, fieldClass } from "@/components/filter-fields";
@@ -121,10 +124,9 @@ function Missed() {
             onChange={(e) => setSearch(e.target.value)}
           />
           <label className="flex items-center gap-2 text-sm">
-            <input
-              type="checkbox"
+            <Checkbox
               checked={archived}
-              onChange={(e) => setArchived(e.target.checked)}
+              onCheckedChange={(checked) => setArchived(checked === true)}
             />
             Show archived
           </label>
@@ -216,21 +218,21 @@ function Missed() {
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               {formField("symbol", "Symbol")}
               <Field label="Direction">
-                <select
+                <OptionSelect
                   className={fieldClass}
                   value={draft.direction}
-                  onChange={(e) => setDraft({ ...draft, direction: e.target.value })}
+                  onValueChange={(next) => setDraft({ ...draft, direction: next })}
                 >
                   <option value="long">Long</option>
                   <option value="short">Short</option>
-                </select>
+                </OptionSelect>
               </Field>
               {formField("observedAt", "Observed at (device time)", "datetime-local")}
               <Field label="Strategy">
-                <select
+                <OptionSelect
                   className={fieldClass}
                   value={draft.playbookId}
-                  onChange={(e) => setDraft({ ...draft, playbookId: e.target.value })}
+                  onValueChange={(next) => setDraft({ ...draft, playbookId: next })}
                 >
                   <option value="">No strategy</option>
                   {books?.playbooks.map((b) => (
@@ -238,7 +240,7 @@ function Missed() {
                       {b.name}
                     </option>
                   ))}
-                </select>
+                </OptionSelect>
               </Field>
             </div>
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">

--- a/apps/web/src/app/notebook/page.tsx
+++ b/apps/web/src/app/notebook/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { OptionSelect } from "@/components/ui/option-select";
 
 import { Suspense, useRef, useState } from "react";
 import { ArrowLeft, FolderPlus, Plus, Search } from "lucide-react";
@@ -183,10 +184,10 @@ function Notebook() {
         <div className="notebook-list min-w-0 overflow-y-auto border-r">
           <div className="sticky top-0 z-[1] space-y-2 border-b bg-background p-2">
             <div className="flex min-w-0 items-center gap-2 xl:hidden">
-              <select
+              <OptionSelect
                 aria-label="Note folder"
                 value={folder}
-                onChange={(event) => setFolder(event.target.value)}
+                onValueChange={(next) => setFolder(next)}
                 className="h-9 min-w-0 flex-1 rounded-lg border bg-card px-2 text-sm"
               >
                 <option value="all">All notes</option>
@@ -197,7 +198,7 @@ function Notebook() {
                       {item.name}
                     </option>
                   ))}
-              </select>
+              </OptionSelect>
               <Button
                 variant="ghost"
                 size="icon"

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -9,11 +9,13 @@ import type {
   EquityPoint,
   TradeMetrics,
 } from "@luxalgo/journal-core";
+import { relativeDrawdownCurve } from "@luxalgo/journal-core";
 import { CalendarPnl } from "@/components/calendar-pnl";
 import { DailyBars } from "@/components/charts/daily-bars";
 import { EdgeRadar } from "@/components/charts/edge-radar";
 import { EquityArea } from "@/components/charts/equity-area";
 import { Gauge } from "@/components/charts/gauge";
+import { RelativeDrawdownBars } from "@/components/charts/relative-drawdown-bars";
 import { TimeHeatmap } from "@/components/charts/time-heatmap";
 import {
   ArrowUpDown,
@@ -35,7 +37,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { HelpHint, Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { postJson, useApi } from "@/lib/use-api";
 import { cn, fmtDuration, fmtMoney, fmtNumber, fmtPercent } from "@/lib/utils";
 
@@ -48,6 +50,7 @@ interface Bucket {
 
 interface StatsPayload {
   metrics: TradeMetrics;
+  initialBalance: number;
   edgeScore: EdgeScore;
   days: DayStats[];
   dailyCumulative: EquityPoint[];
@@ -137,7 +140,7 @@ function Dashboard() {
     : null;
 
   return (
-    <TooltipProvider delayDuration={200}>
+    <>
       <FilterBar title="Dashboard" />
       <DashboardLayout
         widgets={[
@@ -145,6 +148,7 @@ function Dashboard() {
             id: "widget-0",
             label: "Net P&L",
             size: "small",
+            layoutGroup: "summary",
             content: (
               <Card className="h-full">
                 <StatHeader
@@ -180,6 +184,7 @@ function Dashboard() {
             id: "widget-1",
             label: "Trade win %",
             size: "small",
+            layoutGroup: "summary",
             content: (
               <Card className="h-full">
                 <StatHeader
@@ -202,6 +207,7 @@ function Dashboard() {
             id: "widget-2",
             label: "Profit factor",
             size: "small",
+            layoutGroup: "summary",
             content: (
               <Card className="h-full">
                 <StatHeader
@@ -228,6 +234,7 @@ function Dashboard() {
             id: "widget-3",
             label: "Day win %",
             size: "small",
+            layoutGroup: "summary",
             content: (
               <Card className="h-full">
                 <StatHeader
@@ -246,6 +253,7 @@ function Dashboard() {
             id: "widget-4",
             label: "Avg win / loss",
             size: "small",
+            layoutGroup: "summary",
             content: (
               <Card className="h-full">
                 <StatHeader
@@ -259,7 +267,7 @@ function Dashboard() {
                   </div>
                   {m.avgWin !== null && m.avgLoss !== null && m.avgWin + m.avgLoss > 0 && (
                     <div
-                      className="mt-2 flex h-1.5 gap-0.5"
+                      className="journal-progress-visual mt-2 flex h-1.5 gap-0.5"
                       role="img"
                       aria-label="Average win vs average loss, to scale"
                     >
@@ -298,10 +306,17 @@ function Dashboard() {
             id: "widget-5",
             label: "Edge Score",
             size: "medium",
+            layoutGroup: "visuals",
             content: (
-              <Card className="h-full">
+              <Card className="dashboard-visual-card h-full">
                 <CardHeader className="flex-row items-center justify-between">
-                  <CardTitle>Edge Score</CardTitle>
+                  <div className="flex min-w-0 items-center gap-1">
+                    <CardTitle>Edge Score</CardTitle>
+                    <HelpHint heading="Edge Score">
+                      A 0–100 score combining win rate, profit factor, average win/loss, drawdown,
+                      recovery, and consistency. Requires at least five closed trades.
+                    </HelpHint>
+                  </div>
                   <span className="text-2xl font-semibold tracking-tight tnum">
                     {edgeScore.score === null ? (
                       "–"
@@ -311,7 +326,7 @@ function Dashboard() {
                     <span className="text-xs text-muted-foreground"> /100</span>
                   </span>
                 </CardHeader>
-                <CardContent>
+                <CardContent className="dashboard-visual-card-content">
                   {edgeScore.score === null ? (
                     <p className="py-8 text-center text-sm text-muted-foreground">
                       Needs 5+ closed trades. The formula is open —{" "}
@@ -326,7 +341,7 @@ function Dashboard() {
                       .
                     </p>
                   ) : (
-                    <EdgeRadar components={edgeScore.components} />
+                    <EdgeRadar components={edgeScore.components} height="100%" />
                   )}
                 </CardContent>
               </Card>
@@ -336,14 +351,22 @@ function Dashboard() {
             id: "widget-6",
             label: "Cumulative P&L",
             size: "medium",
+            layoutGroup: "visuals",
             content: (
-              <Card className="h-full">
-                <CardHeader>
+              <Card className="dashboard-visual-card h-full">
+                <CardHeader className="flex-row items-center justify-between">
                   <CardTitle>Daily net cumulative P&L</CardTitle>
+                  <HelpHint heading="Cumulative P&L">
+                    Running total of net profit and loss over the selected period. The drawdown bars
+                    below show declines from the running equity peak.
+                  </HelpHint>
                 </CardHeader>
                 <CardContent>
                   <EquityArea
                     data={data.dailyCumulative.map((p) => ({ t: p.t, cumNetPnl: p.cumNetPnl }))}
+                  />
+                  <RelativeDrawdownBars
+                    data={relativeDrawdownCurve(data.dailyCumulative, data.initialBalance)}
                   />
                 </CardContent>
               </Card>
@@ -353,13 +376,21 @@ function Dashboard() {
             id: "widget-7",
             label: "Daily P&L",
             size: "medium",
+            layoutGroup: "visuals",
             content: (
-              <Card className="h-full">
-                <CardHeader>
+              <Card className="dashboard-visual-card h-full">
+                <CardHeader className="flex-row items-center justify-between">
                   <CardTitle>Net daily P&L</CardTitle>
+                  <HelpHint heading="Daily P&L">
+                    Net profit or loss for each trading day. Bars above zero are profitable; bars
+                    below zero are losses.
+                  </HelpHint>
                 </CardHeader>
-                <CardContent>
-                  <DailyBars data={data.days.map((d) => ({ date: d.date, netPnl: d.netPnl }))} />
+                <CardContent className="dashboard-visual-card-content">
+                  <DailyBars
+                    data={data.days.map((d) => ({ date: d.date, netPnl: d.netPnl }))}
+                    height="100%"
+                  />
                 </CardContent>
               </Card>
             ),
@@ -368,6 +399,7 @@ function Dashboard() {
             id: "widget-8",
             label: "Calendar",
             size: "wide",
+            layoutGroup: "detail",
             content: (
               <Card className="h-full">
                 <CardHeader className="flex-row items-center justify-between">
@@ -394,6 +426,7 @@ function Dashboard() {
             id: "widget-9",
             label: "Activity",
             size: "medium",
+            layoutGroup: "detail",
             content: (
               <Card className="h-full">
                 <CardHeader>
@@ -469,6 +502,7 @@ function Dashboard() {
             id: "widget-10",
             label: "Max drawdown",
             size: "small",
+            layoutGroup: "secondary",
             content: (
               <Card className="h-full">
                 <StatHeader
@@ -494,6 +528,7 @@ function Dashboard() {
             id: "widget-11",
             label: "Streaks",
             size: "small",
+            layoutGroup: "secondary",
             content: (
               <Card className="h-full">
                 <StatHeader
@@ -520,6 +555,7 @@ function Dashboard() {
             id: "widget-12",
             label: "Expectancy / trade",
             size: "small",
+            layoutGroup: "secondary",
             content: (
               <Card className="h-full">
                 <StatHeader
@@ -546,6 +582,7 @@ function Dashboard() {
             id: "widget-13",
             label: "Avg duration",
             size: "small",
+            layoutGroup: "secondary",
             content: (
               <Card className="h-full">
                 <StatHeader
@@ -566,6 +603,7 @@ function Dashboard() {
             id: "widget-14",
             label: "Best / worst day",
             size: "small",
+            layoutGroup: "secondary",
             content: (
               <Card className="h-full">
                 <StatHeader
@@ -596,10 +634,15 @@ function Dashboard() {
             id: "widget-15",
             label: "Trade time performance",
             size: "full",
+            layoutGroup: "full",
             content: (
               <Card className="h-full">
-                <CardHeader>
+                <CardHeader className="flex-row items-center justify-between">
                   <CardTitle>Trade time performance</CardTitle>
+                  <HelpHint heading="Trade time performance">
+                    Trades grouped by their opening hour. The upper chart shows net P&L; the lower
+                    chart shows trade count.
+                  </HelpHint>
                 </CardHeader>
                 <CardContent>
                   <TimeHeatmap
@@ -615,7 +658,7 @@ function Dashboard() {
           },
         ]}
       />
-    </TooltipProvider>
+    </>
   );
 }
 
@@ -636,7 +679,10 @@ function StatHeader({
         <TooltipTrigger className="cursor-help" aria-label={`About ${title}`}>
           <Icon className="h-3.5 w-3.5 text-muted-foreground/70" />
         </TooltipTrigger>
-        <TooltipContent>{hint}</TooltipContent>
+        <TooltipContent>
+          <div className="mb-1 font-semibold">{title}</div>
+          <div className="text-muted-foreground">{hint}</div>
+        </TooltipContent>
       </Tooltip>
     </CardHeader>
   );

--- a/apps/web/src/app/progress/page.tsx
+++ b/apps/web/src/app/progress/page.tsx
@@ -1,4 +1,9 @@
 "use client";
+import { DatePicker } from "@/components/ui/date-picker";
+import { OptionSelect } from "@/components/ui/option-select";
+import { Checkbox } from "@/components/ui/checkbox";
+
+import { HoverHint } from "@/components/ui/tooltip";
 import { Suspense, useState } from "react";
 import { FilterBar } from "@/components/filter-bar";
 import { Field, fieldClass } from "@/components/filter-fields";
@@ -87,13 +92,11 @@ function Progress() {
                 </p>
               </div>
               <Field label="Review date">
-                <input
-                  aria-label="Progress date"
-                  type="date"
-                  className={fieldClass}
+                <DatePicker
+                  label="Progress date"
                   value={selected}
                   max={data?.today}
-                  onChange={(e) => setDate(e.target.value)}
+                  onValueChange={setDate}
                 />
               </Field>
             </div>
@@ -123,17 +126,16 @@ function Progress() {
                   .map((r) => (
                     <div key={r.id} className="flex items-start justify-between gap-2">
                       <label className="flex items-start gap-3 text-sm">
-                        <input
+                        <Checkbox
                           className="mt-1"
-                          type="checkbox"
                           checked={
                             data?.checks.some(
                               (c) => c.ruleId === r.id && c.date === selected && c.done,
                             ) ?? false
                           }
                           disabled={busy || selected > (data?.today ?? "")}
-                          onChange={(e) =>
-                            void act({ ruleId: r.id, date: selected, done: e.target.checked })
+                          onCheckedChange={(checked) =>
+                            void act({ ruleId: r.id, date: selected, done: checked === true })
                           }
                         />
                         {r.title}
@@ -165,19 +167,24 @@ function Progress() {
           <CardContent>
             <div className="grid grid-flow-col grid-rows-7 gap-1 overflow-x-auto">
               {days.map((d) => (
-                <button
+                <HoverHint
                   key={d.date}
-                  aria-label={`${d.date}: ${d.completed}/${d.total} complete`}
-                  title={`${d.date} · ${d.completed}/${d.total}`}
-                  onClick={() => setDate(d.date)}
-                  className={`min-h-7 min-w-7 rounded border ${selected === d.date ? "border-foreground" : "border-transparent"}`}
-                  style={{
-                    background:
-                      d.score === null
-                        ? "var(--muted)"
-                        : `color-mix(in srgb, var(--brand) ${15 + d.score * 75}%, var(--card))`,
-                  }}
-                />
+                  heading={d.date}
+                  content={`${d.completed} of ${d.total} routines completed`}
+                >
+                  <button
+                    key={d.date}
+                    aria-label={`${d.date}: ${d.completed}/${d.total} complete`}
+                    onClick={() => setDate(d.date)}
+                    className={`min-h-7 min-w-7 rounded border ${selected === d.date ? "border-foreground" : "border-transparent"}`}
+                    style={{
+                      background:
+                        d.score === null
+                          ? "var(--muted)"
+                          : `color-mix(in srgb, var(--brand) ${15 + d.score * 75}%, var(--card))`,
+                    }}
+                  />
+                </HoverHint>
               ))}
             </div>
             <p className="mt-3 text-xs text-muted-foreground">
@@ -200,25 +207,24 @@ function Progress() {
               />
             </Field>
             <Field label="When">
-              <select
+              <OptionSelect
                 className={fieldClass}
                 value={stage}
-                onChange={(e) => setStage(e.target.value)}
+                onValueChange={(next) => setStage(next)}
               >
                 {STAGES.map((s) => (
                   <option key={s}>{s}</option>
                 ))}
-              </select>
+              </OptionSelect>
             </Field>
             <div className="flex flex-wrap gap-3">
               {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((day, i) => (
                 <label key={day} className="flex items-center gap-1 text-xs">
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={weekdays.includes(i)}
-                    onChange={(e) =>
+                    onCheckedChange={(checked) =>
                       setWeekdays(
-                        e.target.checked ? [...weekdays, i] : weekdays.filter((n) => n !== i),
+                        checked === true ? [...weekdays, i] : weekdays.filter((n) => n !== i),
                       )
                     }
                   />

--- a/apps/web/src/app/reports/page.tsx
+++ b/apps/web/src/app/reports/page.tsx
@@ -1,5 +1,9 @@
 "use client";
+import { OptionSelect } from "@/components/ui/option-select";
+
+import { HoverHint } from "@/components/ui/tooltip";
 import { Suspense, useState } from "react";
+import dynamic from "next/dynamic";
 import {
   DIMENSIONS,
   type Dimension,
@@ -18,6 +22,26 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { useApi } from "@/lib/use-api";
 import { describeFilters } from "@/lib/filter-description";
 import { fmtDuration } from "@/lib/utils";
+const TradeExplorer = dynamic(
+  () => import("@/components/trade-explorer").then((module) => module.TradeExplorer),
+  {
+    loading: () => (
+      <p role="status" className="py-6 text-sm text-muted-foreground">
+        Loading trade explorer…
+      </p>
+    ),
+  },
+);
+const PerformanceTrendsReport = dynamic(
+  () => import("@/components/performance-trends").then((module) => module.PerformanceTrendsReport),
+  {
+    loading: () => (
+      <p role="status" className="py-6 text-sm text-muted-foreground">
+        Loading performance trends…
+      </p>
+    ),
+  },
+);
 interface Group extends GroupSummary {
   row: string;
   column: string;
@@ -71,17 +95,17 @@ function DimensionSelect({
 }) {
   return (
     <Field label={label}>
-      <select
+      <OptionSelect
         className={fieldClass}
         value={value}
-        onChange={(e) => onChange(e.target.value as Dimension)}
+        onValueChange={(next) => onChange(next as Dimension)}
       >
         {Object.entries(DIMENSIONS).map(([key, label]) => (
           <option key={key} value={key}>
             {label}
           </option>
         ))}
-      </select>
+      </OptionSelect>
     </Field>
   );
 }
@@ -143,20 +167,25 @@ function Breakdown({
                   {columns.map((c) => {
                     const g = cells.get(JSON.stringify([r, c]));
                     return (
-                      <td
+                      <HoverHint
                         key={c}
-                        className="border border-background p-2 text-center tabular-nums"
-                        style={{
-                          background: g
-                            ? `color-mix(in srgb, ${g.netPnl >= 0 ? "var(--profit-fill)" : "var(--loss)"} ${8 + (Math.abs(g.netPnl) / max) * 35}%, transparent)`
-                            : undefined,
-                        }}
-                        title={
+                        content={
                           g ? `${g.trades} trades · Win rate ${percent(g.winRate)}` : "No trades"
                         }
                       >
-                        {g ? <MonetaryValue>{number(g.netPnl)}</MonetaryValue> : "-"}
-                      </td>
+                        <td
+                          key={c}
+                          className="border border-background p-2 text-center tabular-nums"
+                          style={{
+                            background: g
+                              ? `color-mix(in srgb, ${g.netPnl >= 0 ? "var(--profit-fill)" : "var(--loss)"} ${8 + (Math.abs(g.netPnl) / max) * 35}%, transparent)`
+                              : undefined,
+                          }}
+                          tabIndex={0}
+                        >
+                          {g ? <MonetaryValue>{number(g.netPnl)}</MonetaryValue> : "-"}
+                        </td>
+                      </HoverHint>
                     );
                   })}
                 </tr>
@@ -236,7 +265,9 @@ export default function ReportsPage() {
 }
 function Reports() {
   const { query, values } = useFilters();
-  const [mode, setMode] = useState<"overview" | "breakdown" | "cross" | "compare">("overview"),
+  const [mode, setMode] = useState<
+      "overview" | "trends" | "explorer" | "breakdown" | "cross" | "compare"
+    >("overview"),
     [primary, setPrimary] = useState<Dimension>("symbol"),
     [secondary, setSecondary] = useState<Dimension>("weekday");
   const { data, error, loading } = useApi<Analysis>(
@@ -254,6 +285,8 @@ function Reports() {
           {(
             [
               ["overview", "Overview"],
+              ["trends", "Performance trends"],
+              ["explorer", "Trade explorer"],
               ["breakdown", "Breakdowns"],
               ["cross", "Cross-analysis"],
               ["compare", "Compare groups"],
@@ -270,90 +303,100 @@ function Reports() {
             </Button>
           ))}
         </div>
-        {mode === "overview" ? (
-          <ReportOverview query={query} filters={values} />
-        ) : mode === "compare" ? (
-          <Comparison key={query} initial={values} />
-        ) : (
-          <>
-            <Card>
-              <CardHeader>
-                <div className="flex flex-wrap items-end justify-between gap-4">
-                  <div className="flex flex-wrap gap-3">
-                    <DimensionSelect label="Group by" value={primary} onChange={setPrimary} />
-                    {mode === "cross" && (
-                      <DimensionSelect label="Then by" value={secondary} onChange={setSecondary} />
-                    )}
-                  </div>
-                  {data && !multi && (
-                    <ReviewExport
-                      containsFinancialData
-                      document={{
-                        title:
-                          mode === "cross"
-                            ? `${DIMENSIONS[primary]} by ${DIMENSIONS[secondary]}`
-                            : `${DIMENSIONS[primary]} performance`,
-                        subtitle: `${data.timeZone} · ${data.currencies[0] ?? "Account currency"}`,
-                        lines: [
-                          `Filters: ${describeFilters(values, data.accounts, data.playbooks)}`,
-                          `Closed trades: ${data.summary.trades} | Net P&L: ${number(data.summary.netPnl)} | Win rate: ${percent(data.summary.winRate)}`,
-                          "",
-                          ...data.groups.map(
-                            (g) =>
-                              `${labels(data, g.row)}${g.column ? ` / ${labels(data, g.column)}` : ""}: ${g.trades} trades | P&L ${number(g.netPnl)} | Win ${percent(g.winRate)} | Planned ${number(g.avgPlannedR)}R | Realized ${number(g.avgRealizedR)}R | Volume ${number(g.volume)} | Holding time ${fmtDuration(g.avgDurationMs)}`,
-                          ),
-                        ],
-                      }}
-                    />
-                  )}
-                </div>
-              </CardHeader>
-              <CardContent>
-                {error ? (
-                  <p role="alert" className="text-destructive">
-                    {error}
-                  </p>
-                ) : loading ? (
-                  <p className="text-sm text-muted-foreground">Loading report…</p>
-                ) : multi ? (
-                  <p className="text-sm">
-                    These accounts use different currencies ({data?.currencies.join(", ")}). Select
-                    accounts with the same currency in Filters to compare monetary results.
-                  </p>
-                ) : data ? (
-                  <Summary data={data} />
-                ) : null}
-              </CardContent>
-            </Card>
-            {data && !multi && !loading && (
+        <div key={mode} className="journal-report-section space-y-4" data-report-section={mode}>
+          {mode === "overview" ? (
+            <ReportOverview query={query} filters={values} />
+          ) : mode === "trends" ? (
+            <PerformanceTrendsReport key={query} query={query} />
+          ) : mode === "explorer" ? (
+            <TradeExplorer key={query} query={query} />
+          ) : mode === "compare" ? (
+            <Comparison key={query} initial={values} />
+          ) : (
+            <>
               <Card>
                 <CardHeader>
-                  <CardTitle>
-                    {mode === "cross"
-                      ? `${DIMENSIONS[primary]} × ${DIMENSIONS[secondary]}`
-                      : `Performance by ${DIMENSIONS[primary].toLowerCase()}`}
-                  </CardTitle>
+                  <div className="flex flex-wrap items-end justify-between gap-4">
+                    <div className="flex flex-wrap gap-3">
+                      <DimensionSelect label="Group by" value={primary} onChange={setPrimary} />
+                      {mode === "cross" && (
+                        <DimensionSelect
+                          label="Then by"
+                          value={secondary}
+                          onChange={setSecondary}
+                        />
+                      )}
+                    </div>
+                    {data && !multi && (
+                      <ReviewExport
+                        containsFinancialData
+                        document={{
+                          title:
+                            mode === "cross"
+                              ? `${DIMENSIONS[primary]} by ${DIMENSIONS[secondary]}`
+                              : `${DIMENSIONS[primary]} performance`,
+                          subtitle: `${data.timeZone} · ${data.currencies[0] ?? "Account currency"}`,
+                          lines: [
+                            `Filters: ${describeFilters(values, data.accounts, data.playbooks)}`,
+                            `Closed trades: ${data.summary.trades} | Net P&L: ${number(data.summary.netPnl)} | Win rate: ${percent(data.summary.winRate)}`,
+                            "",
+                            ...data.groups.map(
+                              (g) =>
+                                `${labels(data, g.row)}${g.column ? ` / ${labels(data, g.column)}` : ""}: ${g.trades} trades | P&L ${number(g.netPnl)} | Win ${percent(g.winRate)} | Planned ${number(g.avgPlannedR)}R | Realized ${number(g.avgRealizedR)}R | Volume ${number(g.volume)} | Holding time ${fmtDuration(g.avgDurationMs)}`,
+                            ),
+                          ],
+                        }}
+                      />
+                    )}
+                  </div>
                 </CardHeader>
                 <CardContent>
-                  <Breakdown
-                    data={data}
-                    cross={mode === "cross"}
-                    primary={primary}
-                    secondary={secondary}
-                  />
+                  {error ? (
+                    <p role="alert" className="text-destructive">
+                      {error}
+                    </p>
+                  ) : loading ? (
+                    <p className="text-sm text-muted-foreground">Loading report…</p>
+                  ) : multi ? (
+                    <p className="text-sm">
+                      These accounts use different currencies ({data?.currencies.join(", ")}).
+                      Select accounts with the same currency in Filters to compare monetary results.
+                    </p>
+                  ) : data ? (
+                    <Summary data={data} />
+                  ) : null}
                 </CardContent>
               </Card>
-            )}
-            <p className="text-xs leading-relaxed text-muted-foreground">
-              Closed trades only. Dates use the closing day; weekday and entry time use the opening
-              time in {data?.timeZone ?? "your journal timezone"}. Volume is total entry quantity. R
-              uses weighted entry and total entry quantity; missing or invalid risk inputs are
-              excluded from R averages. Derivatives require a configured multiplier for realized R.
-              Multiple tags or mistakes can place a trade in more than one group, so those group
-              totals can overlap.
-            </p>
-          </>
-        )}
+              {data && !multi && !loading && (
+                <Card>
+                  <CardHeader>
+                    <CardTitle>
+                      {mode === "cross"
+                        ? `${DIMENSIONS[primary]} × ${DIMENSIONS[secondary]}`
+                        : `Performance by ${DIMENSIONS[primary].toLowerCase()}`}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <Breakdown
+                      data={data}
+                      cross={mode === "cross"}
+                      primary={primary}
+                      secondary={secondary}
+                    />
+                  </CardContent>
+                </Card>
+              )}
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                Closed trades only. Dates use the closing day; weekday and entry time use the
+                opening time in {data?.timeZone ?? "your journal timezone"}. Volume is total entry
+                quantity. R uses weighted entry and total entry quantity; missing or invalid risk
+                inputs are excluded from R averages. Derivatives require a configured multiplier for
+                realized R. Multiple tags or mistakes can place a trade in more than one group, so
+                those group totals can overlap.
+              </p>
+            </>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -114,7 +114,7 @@ function Settings() {
           </CardContent>
         </Card>
 
-        <Card>
+        <Card id="ai-settings" className="scroll-mt-24">
           <CardHeader>
             <CardTitle>AI (bring your own key)</CardTitle>
           </CardHeader>

--- a/apps/web/src/app/trades/[key]/page.tsx
+++ b/apps/web/src/app/trades/[key]/page.tsx
@@ -1,4 +1,6 @@
 "use client";
+import { AiNotice } from "@/components/ai-notice";
+import { Checkbox } from "@/components/ui/checkbox";
 
 import { use, useEffect, useMemo, useRef, useState } from "react";
 import { Sparkles, Star } from "lucide-react";
@@ -90,6 +92,7 @@ function TradeView({ tradeKey }: { tradeKey: string }) {
   );
   const [aiBusy, setAiBusy] = useState(false);
   const [critique, setCritique] = useState<string | null>(null);
+  const [aiError, setAiError] = useState<string | null>(null);
 
   if (!data) {
     return (
@@ -135,11 +138,12 @@ function TradeView({ tradeKey }: { tradeKey: string }) {
 
   const askCritique = async () => {
     setAiBusy(true);
+    setAiError(null);
     try {
       const result = await postJson<{ critique: string }>("/api/ai/critique", { key: tradeKey });
       setCritique(result.critique);
     } catch (error) {
-      alert(error instanceof Error ? error.message : "AI critique failed");
+      setAiError(error instanceof Error ? error.message : "AI critique failed");
     } finally {
       setAiBusy(false);
     }
@@ -268,6 +272,15 @@ function TradeView({ tradeKey }: { tradeKey: string }) {
                 {aiBusy ? "Thinking…" : "Critique this trade"}
               </Button>
             </CardHeader>
+            {aiError && (
+              <CardContent>
+                <AiNotice
+                  error={aiError}
+                  onRetry={() => void askCritique()}
+                  onDismiss={() => setAiError(null)}
+                />
+              </CardContent>
+            )}
             {critique && (
               <CardContent>
                 <p className="whitespace-pre-wrap text-sm leading-relaxed">{critique}</p>
@@ -350,10 +363,9 @@ function AnnotationsCard({
             ))}
           </div>
           <label className="flex items-center gap-2 text-sm">
-            <input
-              type="checkbox"
+            <Checkbox
               checked={trade.reviewedAt !== null}
-              onChange={(event) => void onPatch({ reviewed: event.target.checked })}
+              onCheckedChange={(checked) => void onPatch({ reviewed: checked === true })}
             />
             Reviewed
           </label>

--- a/apps/web/src/app/trades/page.tsx
+++ b/apps/web/src/app/trades/page.tsx
@@ -24,6 +24,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
+import Loading from "@/app/loading";
 import { postJson, useApi } from "@/lib/use-api";
 import { cn, fmtDuration, fmtMoney, fmtNumber, fmtPercent } from "@/lib/utils";
 
@@ -57,9 +58,11 @@ const features = tableFeatures({
   sortFns,
 });
 
+const EMPTY_TRADES: TradeRow[] = [];
+
 export default function TradesPage() {
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <Trades />
     </Suspense>
   );
@@ -84,7 +87,13 @@ function Trades() {
         enableSorting: false,
         header: ({ table }) => (
           <Checkbox
-            checked={table.getIsAllRowsSelected()}
+            checked={
+              table.getIsAllRowsSelected()
+                ? true
+                : table.getIsSomeRowsSelected()
+                  ? "indeterminate"
+                  : false
+            }
             onCheckedChange={(value) => table.toggleAllRowsSelected(value === true)}
             aria-label="Select all matching trades"
           />
@@ -245,7 +254,7 @@ function Trades() {
   const table = useTable({
     features,
     columns,
-    data: data?.trades ?? [],
+    data: data?.trades ?? EMPTY_TRADES,
     getRowId: (row) => row.key,
     initialState: {
       sorting: [{ id: "closedAt", desc: true }],

--- a/apps/web/src/components/ai-notice.tsx
+++ b/apps/web/src/components/ai-notice.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import Link from "next/link";
+import { useId } from "react";
+import { ArrowUpRight, CircleAlert, Sparkles, X } from "lucide-react";
+import { aiFeedback } from "@/lib/ai-feedback";
+import { Button } from "./ui/button";
+
+export function AiNotice({
+  error,
+  onRetry,
+  onDismiss,
+}: {
+  error: string;
+  onRetry: () => void;
+  onDismiss: () => void;
+}) {
+  const feedback = aiFeedback(error);
+  const id = useId();
+  const Icon = feedback.tone === "error" ? CircleAlert : Sparkles;
+  return (
+    <div
+      data-ai-notice
+      role={feedback.tone === "error" ? "alert" : "status"}
+      aria-labelledby={`${id}-title`}
+      aria-describedby={`${id}-description`}
+      className="flex items-start gap-3 rounded-xl border bg-muted/25 p-4"
+    >
+      <span
+        className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${feedback.tone === "error" ? "bg-destructive/10 text-destructive" : "bg-muted text-muted-foreground"}`}
+      >
+        <Icon className="h-4 w-4" aria-hidden="true" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <p id={`${id}-title`} className="text-sm font-medium leading-5">
+          {feedback.title}
+        </p>
+        <p
+          id={`${id}-description`}
+          className="mt-1 max-w-2xl text-xs leading-relaxed text-muted-foreground"
+        >
+          {feedback.description}
+        </p>
+        {feedback.action ? (
+          <Link
+            href={feedback.action.href}
+            className="mt-3 inline-flex items-center gap-1 rounded text-xs font-medium underline decoration-muted-foreground/40 underline-offset-4 hover:decoration-current"
+          >
+            {feedback.action.label}
+            <ArrowUpRight className="h-3.5 w-3.5" aria-hidden="true" />
+          </Link>
+        ) : feedback.retry ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="mt-3 h-8 text-xs"
+            onClick={onRetry}
+          >
+            Try again
+          </Button>
+        ) : null}
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="-mr-1 -mt-1 h-7 w-7 shrink-0 text-muted-foreground"
+        aria-label="Dismiss AI notice"
+        onClick={onDismiss}
+      >
+        <X className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/ask-journal.tsx
+++ b/apps/web/src/components/ask-journal.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { postJson } from "@/lib/use-api";
+import { AiNotice } from "./ai-notice";
 
 const SUGGESTIONS = [
   "What's my most expensive mistake?",
@@ -19,10 +20,15 @@ export function AskJournal() {
   const [answer, setAnswer] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [lastQuestion, setLastQuestion] = useState("");
 
   const ask = async (q: string) => {
+    if (busy || !q.trim()) return;
+    q = q.trim();
+    setLastQuestion(q);
     setBusy(true);
     setError(null);
+    setAnswer(null);
     try {
       const result = await postJson<{ answer: string }>("/api/ai/ask", { question: q });
       setAnswer(result.answer);
@@ -43,15 +49,16 @@ export function AskJournal() {
           className="flex gap-2"
           onSubmit={(event) => {
             event.preventDefault();
-            if (question) void ask(question);
+            if (question.trim()) void ask(question);
           }}
         >
           <Input
+            aria-label="Ask your journal a question"
             value={question}
             onChange={(event) => setQuestion(event.target.value)}
             placeholder="Why do my Monday shorts keep failing?"
           />
-          <Button type="submit" disabled={busy || !question}>
+          <Button type="submit" disabled={busy || !question.trim()}>
             <Sparkles />
             {busy ? "Thinking…" : "Ask"}
           </Button>
@@ -60,7 +67,8 @@ export function AskJournal() {
           {SUGGESTIONS.map((suggestion) => (
             <button
               key={suggestion}
-              className="rounded-full border px-2.5 py-1 text-xs text-muted-foreground hover:bg-accent"
+              disabled={busy}
+              className="rounded-full border px-2.5 py-1 text-xs text-muted-foreground hover:bg-accent disabled:cursor-wait disabled:opacity-50"
               onClick={() => {
                 setQuestion(suggestion);
                 void ask(suggestion);
@@ -70,7 +78,13 @@ export function AskJournal() {
             </button>
           ))}
         </div>
-        {error && <p className="text-sm text-loss">{error}</p>}
+        {error && (
+          <AiNotice
+            error={error}
+            onRetry={() => void ask(lastQuestion)}
+            onDismiss={() => setError(null)}
+          />
+        )}
         {answer && <p className="whitespace-pre-wrap pt-1 text-sm leading-relaxed">{answer}</p>}
       </CardContent>
     </Card>

--- a/apps/web/src/components/attachments.tsx
+++ b/apps/web/src/components/attachments.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { HoverHint } from "./ui/tooltip";
 import { useRef, useState } from "react";
 import { Paperclip, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -69,22 +70,23 @@ export function Attachments({
       <div className="grid grid-cols-2 gap-2">
         {data?.attachments.map((a) => (
           <div key={a.id} className="min-w-0 rounded-md border p-2">
-            <a
-              href={`/api/attachments/${a.id}`}
-              target="_blank"
-              rel="noreferrer"
-              className="block"
-              title={a.name}
-            >
-              {a.mime.startsWith("image/") && (
-                <img
-                  src={`/api/attachments/${a.id}`}
-                  alt={a.name}
-                  className="mb-2 h-28 w-full rounded object-contain"
-                />
-              )}
-              <span className="block truncate text-xs underline">{a.name}</span>
-            </a>
+            <HoverHint content={a.name}>
+              <a
+                href={`/api/attachments/${a.id}`}
+                target="_blank"
+                rel="noreferrer"
+                className="block"
+              >
+                {a.mime.startsWith("image/") && (
+                  <img
+                    src={`/api/attachments/${a.id}`}
+                    alt={a.name}
+                    className="mb-2 h-28 w-full rounded object-contain"
+                  />
+                )}
+                <span className="block truncate text-xs underline">{a.name}</span>
+              </a>
+            </HoverHint>
             <div className="mt-1 flex items-center justify-between text-xs text-muted-foreground">
               <span>{Math.round(a.size / 1024)} KB</span>
               <Button

--- a/apps/web/src/components/calendar-insights.tsx
+++ b/apps/web/src/components/calendar-insights.tsx
@@ -1,0 +1,397 @@
+"use client";
+
+import Link from "next/link";
+import dynamic from "next/dynamic";
+import { useState, type ReactNode } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowUpRight, CalendarDays } from "lucide-react";
+import type { DayStats } from "@luxalgo/journal-core";
+import { calendarTradeHref, type CalendarResponse } from "@/lib/calendar-insights";
+import { cn, fmtMoney, fmtPercent } from "@/lib/utils";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { HelpHint, HoverHint } from "./ui/tooltip";
+import { Pnl } from "./pnl";
+import { usePrivacy } from "./privacy";
+// Keep the calendar and summaries usable before the plotting bundle loads.
+const CalendarDailyChart = dynamic(
+  () => import("./charts/calendar-daily-chart").then((module) => module.CalendarDailyChart),
+  {
+    loading: () => (
+      <div
+        role="status"
+        aria-label="Loading daily performance chart"
+        className="h-60 rounded-lg bg-muted/20"
+      />
+    ),
+  },
+);
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  timeZone: "UTC",
+});
+const dateLabel = (date: string) => dateFormatter.format(new Date(`${date}T12:00:00Z`));
+
+function Metric({
+  title,
+  value,
+  detail,
+  hint,
+}: {
+  title: string;
+  value: ReactNode;
+  detail: ReactNode;
+  hint: string;
+}) {
+  return (
+    <Card>
+      <CardHeader className="flex-row items-center justify-between space-y-0">
+        <CardTitle>{title}</CardTitle>
+        <HelpHint heading={title}>{hint}</HelpHint>
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-semibold tracking-tight tabular-nums">{value}</div>
+        <div className="mt-1 text-xs text-muted-foreground">{detail}</div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function CalendarPerformance({ data, query }: { data: CalendarResponse; query: string }) {
+  const { insights: i, scope, timeZone, currencies } = data;
+  const currency = currencies[0] ?? "USD";
+  const mixed = currencies.length > 1;
+  const privateMode = usePrivacy();
+  const router = useRouter();
+  const [weekday, setWeekday] = useState<number | null>(null);
+  const href = (date?: string) => calendarTradeHref(query, scope, date);
+  const money = (value: number | null) =>
+    value === null || mixed ? (
+      <span className="text-muted-foreground">—</span>
+    ) : (
+      <Pnl value={value} currency={currency} />
+    );
+  const selected = weekday === null ? null : i.weekdays[weekday]!;
+  const peak = Math.max(1, ...i.weekdays.map((day) => Math.abs(day.netPnl)));
+  const dayLink = (day: DayStats | null) =>
+    day && !mixed ? (
+      <Link
+        href={href(day.date)}
+        className="inline-flex max-w-full items-center gap-2 rounded text-sm font-medium outline-none hover:underline focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {money(day.netPnl)}
+        <span className="text-xs font-normal text-muted-foreground">{dateLabel(day.date)}</span>
+        <ArrowUpRight aria-hidden="true" className="size-3.5 shrink-0" />
+      </Link>
+    ) : (
+      money(null)
+    );
+  return (
+    <section
+      aria-labelledby="calendar-insights-heading"
+      className="space-y-3"
+      data-calendar-insights
+    >
+      <div className="flex flex-wrap items-end justify-between gap-2 pt-3">
+        <div>
+          <h2 id="calendar-insights-heading" className="text-base font-semibold tracking-tight">
+            Performance insights
+          </h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Visible month × active filters · Closed trades, after fees · {timeZone}
+          </p>
+        </div>
+        {i.trades > 0 && (
+          <Link
+            href={href()}
+            className="inline-flex items-center gap-1 rounded text-xs text-muted-foreground outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            View matching trades <ArrowUpRight aria-hidden="true" className="size-3.5" />
+          </Link>
+        )}
+      </div>
+      {!i.tradingDays ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-2 py-10 text-center">
+            <CalendarDays aria-hidden="true" className="mb-1 size-6 text-muted-foreground" />
+            <h3 className="text-sm font-medium">No closed trades in this view</h3>
+            <p className="max-w-md text-sm text-muted-foreground">
+              Choose another month or adjust your account and filters. Open positions and days
+              without trades aren’t included in performance insights.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          {mixed && (
+            <p
+              role="status"
+              className="rounded-lg border bg-muted/40 px-4 py-3 text-sm text-muted-foreground"
+            >
+              These trades use {currencies.join(", ")}. Select accounts with one currency to compare
+              monetary performance; no exchange-rate conversion is applied.
+            </p>
+          )}
+          <div className="grid gap-3 min-[420px]:grid-cols-2 xl:grid-cols-4">
+            <Metric
+              title="Net P&L"
+              value={money(i.netPnl)}
+              detail={`${i.tradingDays} trading day${i.tradingDays === 1 ? "" : "s"}${mixed ? "" : ` · ${currency}`}`}
+              hint="Sum of net P&L for closed trades in this month and filter selection. Includes fees. No currency conversion."
+            />
+            <Metric
+              title="Average daily P&L"
+              value={money(i.avgDailyPnl)}
+              detail="Per day with closed trades"
+              hint="Net P&L divided by trading days. Days without closed trades are excluded; break-even trading days are included."
+            />
+            <Metric
+              title="Trade win rate"
+              value={fmtPercent(i.winRate)}
+              detail={`${i.wins} wins · ${i.losses} losses · ${i.breakevens} break-even`}
+              hint="Winning closed trades divided by all closed trades, including break-even trades. Uses your journal's configured break-even rule."
+            />
+            <Metric
+              title="Total closed trades"
+              value={
+                <Link
+                  className="rounded outline-none hover:underline focus-visible:ring-2 focus-visible:ring-ring"
+                  href={href()}
+                >
+                  {i.trades}
+                </Link>
+              }
+              detail="Round-trip trades, not executions"
+              hint="Counts completed trades whose closing day falls in the visible month and selected date range, with all other filters applied."
+            />
+          </div>
+          {!mixed && (
+            <>
+              <div className="grid gap-3 md:grid-cols-3">
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Best & worst day</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    <div className="flex flex-wrap items-center justify-between gap-1">
+                      <span className="text-xs text-muted-foreground">Best day</span>
+                      {dayLink(i.bestDay)}
+                    </div>
+                    <div className="flex flex-wrap items-center justify-between gap-1">
+                      <span className="text-xs text-muted-foreground">Worst day</span>
+                      {dayLink(i.worstDay)}
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      {i.tradingDays === 1
+                        ? "One trading day; both extrema are the same."
+                        : "Highest and lowest daily net P&L."}
+                    </p>
+                  </CardContent>
+                </Card>
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Average green & red day</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    <div className="flex items-center justify-between gap-2 text-sm">
+                      <span className="text-xs text-muted-foreground">
+                        {i.greenDays} profitable days
+                      </span>
+                      {money(i.avgGreenDay)}
+                    </div>
+                    <div className="flex items-center justify-between gap-2 text-sm">
+                      <span className="text-xs text-muted-foreground">{i.redDays} losing days</span>
+                      {money(i.avgRedDay)}
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Each average uses only its own group.
+                    </p>
+                  </CardContent>
+                </Card>
+                <Metric
+                  title="Day consistency"
+                  value={fmtPercent(i.profitableDayRate)}
+                  detail={`${i.greenDays} positive · ${i.redDays} negative · ${i.flatDays} flat days`}
+                  hint="Share of trading days with strictly positive net P&L. This is a profitable-day rate, not a risk-adjusted score or a prediction. Flat days stay in the denominator."
+                />
+              </div>
+              <div className="grid items-start gap-3 lg:grid-cols-[minmax(0,1.65fr)_minmax(0,1fr)]">
+                <Card>
+                  <CardHeader>
+                    <h3 className="text-sm font-medium">Daily performance</h3>
+                    <p className="text-xs text-muted-foreground">
+                      Net P&L by closing day · {currency}
+                      {i.tradingDays >= 8 ? " · Dashed line: 5-trading-day average" : ""}
+                    </p>
+                  </CardHeader>
+                  <CardContent>
+                    {i.tradingDays >= 2 ? (
+                      <CalendarDailyChart
+                        data={i.trend}
+                        currency={currency}
+                        onInspect={(date) => router.push(href(date))}
+                      />
+                    ) : (
+                      <div className="flex min-h-40 flex-col items-center justify-center gap-2 rounded-lg bg-muted/30 p-5 text-center">
+                        <span className="text-sm font-medium">A trend needs more than one day</span>
+                        <span className="text-xs text-muted-foreground">
+                          {dateLabel(i.days[0]!.date)} · {money(i.netPnl)} · {i.trades} closed
+                          trades
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          Explore an earlier month with more trading history.
+                        </span>
+                      </div>
+                    )}
+                    <details className="mt-3 border-t pt-3">
+                      <summary className="cursor-pointer rounded text-xs text-muted-foreground outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring">
+                        Daily values & trade links ({i.tradingDays})
+                      </summary>
+                      <div className="mt-2 max-h-60 overflow-auto">
+                        <table className="w-full text-left text-xs">
+                          <caption className="sr-only">
+                            Daily results for the current month and filters
+                          </caption>
+                          <thead className="sticky top-0 bg-card text-muted-foreground">
+                            <tr>
+                              <th scope="col" className="py-2 font-medium">
+                                Closing day
+                              </th>
+                              <th scope="col" className="text-right font-medium">
+                                Trades
+                              </th>
+                              <th scope="col" className="text-right font-medium">
+                                Net P&L
+                              </th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {i.days.map((day) => (
+                              <tr key={day.date} className="border-t">
+                                <th scope="row" className="py-2 font-normal">
+                                  <Link
+                                    href={href(day.date)}
+                                    className="rounded underline underline-offset-4 outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                  >
+                                    {dateLabel(day.date)}
+                                  </Link>
+                                </th>
+                                <td className="text-right tabular-nums">{day.trades}</td>
+                                <td className="text-right">{money(day.netPnl)}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    </details>
+                  </CardContent>
+                </Card>
+                <Card>
+                  <CardHeader>
+                    <h3 className="text-sm font-medium">Performance by weekday</h3>
+                    <p className="text-xs text-muted-foreground">
+                      Closing-day net P&L · {currency} · Select a row
+                    </p>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="mb-3 rounded-lg bg-muted/40 px-3 py-2">
+                      <div className="text-[11px] text-muted-foreground">
+                        Most profitable weekday
+                      </div>
+                      <div className="mt-0.5 flex flex-wrap justify-between gap-1 text-sm font-medium">
+                        {i.mostProfitableWeekday ? (
+                          <>
+                            <span>{i.mostProfitableWeekday.label}</span>
+                            {money(i.mostProfitableWeekday.netPnl)}
+                          </>
+                        ) : (
+                          <span className="text-muted-foreground">No profitable weekday yet</span>
+                        )}
+                      </div>
+                    </div>
+                    <div className="space-y-1">
+                      {i.weekdays.map((day) => (
+                        <HoverHint
+                          key={day.index}
+                          heading={day.label}
+                          content={`${day.days.length} trading days · ${day.trades} closed trades · ${privateMode ? "P&L hidden" : fmtMoney(day.netPnl, currency)}`}
+                        >
+                          <button
+                            type="button"
+                            disabled={!day.trades}
+                            onClick={() => setWeekday(weekday === day.index ? null : day.index)}
+                            aria-pressed={weekday === day.index}
+                            aria-label={`${day.label}: ${day.trades} trades${privateMode ? "" : `, ${fmtMoney(day.netPnl, currency)}`}. Inspect closing days.`}
+                            className={cn(
+                              "grid w-full grid-cols-[2rem_minmax(0,1fr)_5.75rem] items-center gap-2 rounded-md px-2 py-2 text-left text-xs outline-none hover:bg-accent/60 focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-40 disabled:hover:bg-transparent",
+                              weekday === day.index && "bg-accent",
+                            )}
+                          >
+                            <span>{day.label.slice(0, 3)}</span>
+                            <span aria-hidden="true" className="relative h-4">
+                              <span className="absolute inset-y-0 left-1/2 w-px bg-border" />
+                              <span
+                                className={cn(
+                                  "absolute top-1 h-2 rounded-sm",
+                                  day.netPnl > 0
+                                    ? "bg-profit"
+                                    : day.netPnl < 0
+                                      ? "bg-loss"
+                                      : "bg-muted-foreground",
+                                )}
+                                style={{
+                                  left:
+                                    day.netPnl < 0
+                                      ? `${50 - (Math.abs(day.netPnl) / peak) * 50}%`
+                                      : "50%",
+                                  width:
+                                    day.netPnl === 0
+                                      ? "2px"
+                                      : `${(Math.abs(day.netPnl) / peak) * 50}%`,
+                                }}
+                              />
+                            </span>
+                            <span className="text-right">
+                              {day.trades ? money(day.netPnl) : "—"}
+                            </span>
+                          </button>
+                        </HoverHint>
+                      ))}
+                    </div>
+                    {selected && (
+                      <div className="mt-3 border-t pt-3" aria-live="polite">
+                        <p className="mb-2 text-xs font-medium">
+                          {selected.label} · {selected.trades} trades across {selected.days.length}{" "}
+                          days
+                        </p>
+                        <div className="flex flex-wrap gap-2">
+                          {selected.days.map((day) => (
+                            <Link
+                              key={day.date}
+                              href={href(day.date)}
+                              className="rounded-md border px-2 py-1.5 text-xs outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring"
+                            >
+                              {dateLabel(day.date)}{" "}
+                              <span className="text-muted-foreground">· {day.trades} trades</span>
+                            </Link>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              </div>
+              {i.tradingDays < 5 && (
+                <p className="px-1 text-xs text-muted-foreground">
+                  Small sample: {i.tradingDays} trading day{i.tradingDays === 1 ? "" : "s"}. Weekday
+                  results and consistency describe this selection only.
+                </p>
+              )}
+            </>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/calendar-pnl.tsx
+++ b/apps/web/src/components/calendar-pnl.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { HoverHint } from "./ui/tooltip";
 
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
@@ -7,20 +8,36 @@ import { cn, fmtMoney } from "@/lib/utils";
 import { Pnl } from "./pnl";
 import { MonetaryValue, usePrivacy } from "./privacy";
 
-const compactMoney = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  notation: "compact",
-  maximumFractionDigits: 1,
-  signDisplay: "exceptZero",
-});
+const compactFormatters = new Map<string, Intl.NumberFormat>();
+const compactMoney = (value: number, currency: string) => {
+  let formatter = compactFormatters.get(currency);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+      notation: "compact",
+      maximumFractionDigits: 1,
+      signDisplay: "exceptZero",
+    });
+    compactFormatters.set(currency, formatter);
+  }
+  return formatter.format(value);
+};
 
 /**
  * The P&L calendar — an HTML grid, not a chart. Each traded day prints its
  * signed P&L and trade count; the background tint scales with magnitude
  * (lightness carries magnitude, which survives CVD; the number carries sign).
  */
-export function CalendarPnl({ calendar }: { calendar: CalendarMonth }) {
+export function CalendarPnl({
+  calendar,
+  currency = "USD",
+  monetary = true,
+}: {
+  calendar: CalendarMonth;
+  currency?: string;
+  monetary?: boolean;
+}) {
   const maxAbs = Math.max(
     1,
     ...calendar.weeks.flatMap((week) => week.days.map((day) => Math.abs(day?.netPnl ?? 0))),
@@ -37,15 +54,26 @@ export function CalendarPnl({ calendar }: { calendar: CalendarMonth }) {
           Week
         </div>
         {calendar.weeks.map((week, weekIndex) => (
-          <CalendarWeekRow key={weekIndex} week={week} maxAbs={maxAbs} />
+          <CalendarWeekRow
+            key={weekIndex}
+            week={week}
+            maxAbs={maxAbs}
+            currency={currency}
+            monetary={monetary}
+          />
         ))}
       </div>
       <div className="mt-3 flex flex-wrap items-center justify-between gap-x-3 gap-y-1 text-xs sm:text-sm">
         <span className="text-muted-foreground">
-          {calendar.tradingDays} trading days · {calendar.winningDays} green
+          {calendar.tradingDays} trading days {monetary && <>· {calendar.winningDays} green</>}
         </span>
         <span>
-          Month: <Pnl value={calendar.monthNetPnl} className="font-semibold" />
+          Month:{" "}
+          {monetary ? (
+            <Pnl value={calendar.monthNetPnl} currency={currency} className="font-semibold" />
+          ) : (
+            <span className="text-muted-foreground">Multiple currencies</span>
+          )}
         </span>
       </div>
     </div>
@@ -55,9 +83,13 @@ export function CalendarPnl({ calendar }: { calendar: CalendarMonth }) {
 function CalendarWeekRow({
   week,
   maxAbs,
+  currency,
+  monetary,
 }: {
   week: CalendarMonth["weeks"][number];
   maxAbs: number;
+  currency: string;
+  monetary: boolean;
 }) {
   const search = useSearchParams();
   const privacy = usePrivacy();
@@ -67,48 +99,75 @@ function CalendarWeekRow({
         if (!day) return <div key={dayIndex} className="journal-calendar-day rounded-md" />;
         const traded = day.trades > 0;
         const intensity = traded ? 0.1 + 0.38 * (Math.abs(day.netPnl) / maxAbs) : 0;
+        const performance = !monetary
+          ? "neutral"
+          : day.netPnl > 0
+            ? "profit"
+            : day.netPnl < 0
+              ? "loss"
+              : "neutral";
         return (
-          <Link
+          <HoverHint
             key={day.date}
-            href={`/journal/${day.date}?${search}`}
-            title={`${day.date} · ${privacy ? "P&L hidden" : fmtMoney(day.netPnl)} · ${day.trades} trades`}
-            aria-label={`${day.date}, ${privacy ? "P&L hidden" : fmtMoney(day.netPnl)}, ${day.trades} trades`}
-            className={cn(
-              "journal-calendar-day min-w-0 rounded-md border transition-colors hover:border-ring focus-visible:outline focus-visible:outline-ring",
-              !traded && "border-transparent bg-muted/30",
-            )}
-            style={
-              traded
-                ? {
-                    backgroundColor: `color-mix(in oklab, ${
-                      day.netPnl >= 0 ? "var(--profit-fill)" : "var(--loss)"
-                    } ${Math.round(intensity * 100)}%, var(--card))`,
-                  }
-                : undefined
-            }
+            heading={day.date}
+            content={`${!monetary ? "Multiple currencies" : privacy ? "P&L hidden" : fmtMoney(day.netPnl, currency)} · ${day.trades} trades`}
           >
-            <div className="text-muted-foreground">{Number(day.date.slice(8))}</div>
-            {traded && (
-              <>
-                <div className="journal-calendar-full tnum font-medium">
-                  <MonetaryValue>{fmtMoney(day.netPnl)}</MonetaryValue>
-                </div>
-                <div className="journal-calendar-compact tnum font-medium">
-                  <MonetaryValue>{compactMoney.format(day.netPnl)}</MonetaryValue>
-                </div>
-                <div className="journal-calendar-trades text-muted-foreground">
-                  {day.trades} trade{day.trades === 1 ? "" : "s"}
-                </div>
-              </>
-            )}
-          </Link>
+            <Link
+              key={day.date}
+              href={`/journal/${day.date}?${search}`}
+              aria-label={`${day.date}, ${!monetary ? "Multiple currencies" : privacy ? "P&L hidden" : fmtMoney(day.netPnl, currency)}, ${day.trades} trades`}
+              className={cn(
+                "journal-calendar-day journal-calendar-day-link min-w-0 rounded-md border",
+                !traded && "border-transparent bg-muted/30",
+              )}
+              data-performance={performance}
+              style={
+                traded && monetary
+                  ? {
+                      backgroundColor: `color-mix(in oklab, ${
+                        performance === "profit"
+                          ? "var(--profit-fill)"
+                          : performance === "loss"
+                            ? "var(--loss)"
+                            : "var(--neutral-mid)"
+                      } ${Math.round(intensity * 100)}%, var(--card))`,
+                    }
+                  : undefined
+              }
+            >
+              <div className="text-muted-foreground">{Number(day.date.slice(8))}</div>
+              {traded && (
+                <>
+                  <div className="journal-calendar-full tnum font-medium">
+                    {monetary ? (
+                      <MonetaryValue>{fmtMoney(day.netPnl, currency)}</MonetaryValue>
+                    ) : (
+                      "—"
+                    )}
+                  </div>
+                  <div className="journal-calendar-compact tnum font-medium">
+                    {monetary ? (
+                      <MonetaryValue>{compactMoney(day.netPnl, currency)}</MonetaryValue>
+                    ) : (
+                      "—"
+                    )}
+                  </div>
+                  <div className="journal-calendar-trades text-muted-foreground">
+                    {day.trades} trade{day.trades === 1 ? "" : "s"}
+                  </div>
+                </>
+              )}
+            </Link>
+          </HoverHint>
         );
       })}
       <div className="journal-calendar-week flex rounded-md bg-muted/40 p-1.5">
         <span className="journal-calendar-week-label text-muted-foreground">Week total</span>
         {week.weekTrades > 0 ? (
           <>
-            <Pnl value={week.weekNetPnl} className="font-medium" />
+            {monetary && (
+              <Pnl value={week.weekNetPnl} currency={currency} className="font-medium" />
+            )}
             <span className="text-muted-foreground">{week.weekTrades} trades</span>
           </>
         ) : (

--- a/apps/web/src/components/charts/calendar-daily-chart.tsx
+++ b/apps/web/src/components/charts/calendar-daily-chart.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import {
+  Bar,
+  CartesianGrid,
+  Cell,
+  ComposedChart,
+  Line,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { CalendarInsights } from "@/lib/calendar-insights";
+import { fmtMoney } from "@/lib/utils";
+import { usePrivacy } from "../privacy";
+import { ChartFrame } from "./chart-frame";
+import { tooltipStyle, useVizTokens } from "./tokens";
+
+export function CalendarDailyChart({
+  data,
+  currency,
+  onInspect,
+}: {
+  data: CalendarInsights["trend"];
+  currency: string;
+  onInspect: (date: string) => void;
+}) {
+  const tokens = useVizTokens();
+  const privacy = usePrivacy();
+  if (!tokens) return <div className="h-60" />;
+  return (
+    <ChartFrame height={240}>
+      <ResponsiveContainer width="100%" height="100%">
+        <ComposedChart
+          aria-label="Daily net profit and loss. Exact values and trade links are available in the table below."
+          data={data}
+          margin={{ top: 12, right: 8, bottom: 4, left: 0 }}
+          onClick={(state) => {
+            if (
+              typeof state.activeLabel === "string" &&
+              data.some((day) => day.date === state.activeLabel)
+            )
+              onInspect(state.activeLabel);
+          }}
+        >
+          <CartesianGrid stroke={tokens.gridline} vertical={false} />
+          <XAxis
+            dataKey="date"
+            tickFormatter={(date: string) => date.slice(5).replace("-", "/")}
+            minTickGap={24}
+            tick={{ fill: tokens.inkMuted, fontSize: 11 }}
+            tickLine={false}
+            axisLine={{ stroke: tokens.baseline }}
+          />
+          <YAxis
+            width={76}
+            tick={{ fill: tokens.inkMuted, fontSize: 11 }}
+            tickLine={false}
+            axisLine={false}
+            tickFormatter={(value: number) =>
+              privacy ? "••••" : fmtMoney(value, currency).replace(/\.00$/, "")
+            }
+          />
+          <ReferenceLine y={0} stroke={tokens.baseline} />
+          <Tooltip
+            contentStyle={tooltipStyle(tokens)}
+            cursor={{ fill: tokens.gridline, opacity: 0.35 }}
+            formatter={(value, name) => [
+              privacy ? "Hidden" : fmtMoney(Number(value), currency),
+              name === "average" ? "5-trading-day average" : "Daily net P&L",
+            ]}
+          />
+          <Bar dataKey="netPnl" maxBarSize={22} isAnimationActive={false} cursor="pointer">
+            {data.map((day) => (
+              <Cell
+                key={day.date}
+                fill={
+                  day.netPnl > 0
+                    ? tokens.profitFill
+                    : day.netPnl < 0
+                      ? tokens.loss
+                      : tokens.inkMuted
+                }
+              />
+            ))}
+          </Bar>
+          {data.length >= 8 && (
+            <Line
+              dataKey="average"
+              type="linear"
+              stroke={tokens.foreground}
+              strokeWidth={1.5}
+              strokeDasharray="4 3"
+              dot={false}
+              connectNulls={false}
+              isAnimationActive={false}
+            />
+          )}
+        </ComposedChart>
+      </ResponsiveContainer>
+    </ChartFrame>
+  );
+}

--- a/apps/web/src/components/charts/chart-frame.tsx
+++ b/apps/web/src/components/charts/chart-frame.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+/** A bounded plotting surface; animation never changes layout or hit testing. */
+export function ChartFrame({
+  children,
+  height,
+}: {
+  children: ReactNode;
+  height: number | `${number}%`;
+}) {
+  return (
+    <div className="journal-chart-frame" style={{ height }}>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/charts/daily-bars.tsx
+++ b/apps/web/src/components/charts/daily-bars.tsx
@@ -14,6 +14,7 @@ import {
 import { fmtMoney } from "@/lib/utils";
 import { usePrivacy } from "../privacy";
 import { tooltipStyle, useVizTokens } from "./tokens";
+import { ChartFrame } from "./chart-frame";
 
 export interface DailyBarDatum {
   date: string;
@@ -24,51 +25,59 @@ export interface DailyBarDatum {
  * Net daily P&L. Polarity is geometry first (bars grow from the zero baseline);
  * green/red only reinforces. Rounded corners sit at the data end.
  */
-export function DailyBars({ data, height = 240 }: { data: DailyBarDatum[]; height?: number }) {
+export function DailyBars({
+  data,
+  height = 240,
+}: {
+  data: DailyBarDatum[];
+  height?: number | `${number}%`;
+}) {
   const t = useVizTokens();
   const privateMode = usePrivacy();
   if (!t) return <div style={{ height }} />;
   return (
-    <ResponsiveContainer width="100%" height={height}>
-      <BarChart
-        key={String(privateMode)}
-        data={data}
-        margin={{ top: 8, right: 8, bottom: 0, left: 8 }}
-        barCategoryGap="20%"
-      >
-        <CartesianGrid stroke={t.gridline} strokeWidth={1} vertical={false} />
-        <XAxis
-          dataKey="date"
-          tick={{ fill: t.inkMuted, fontSize: 11 }}
-          tickLine={false}
-          axisLine={{ stroke: t.baseline }}
-          minTickGap={48}
-        />
-        <YAxis
-          tick={{ fill: t.inkMuted, fontSize: 11 }}
-          tickLine={false}
-          axisLine={false}
-          width={70}
-          tickFormatter={(value: number) =>
-            privateMode ? "••••" : fmtMoney(value).replace(".00", "")
-          }
-        />
-        <ReferenceLine y={0} stroke={t.baseline} />
-        <Tooltip
-          contentStyle={tooltipStyle(t)}
-          formatter={(value) => [privateMode ? "Hidden" : fmtMoney(Number(value)), "Net P&L"]}
-          cursor={{ fill: t.gridline, opacity: 0.4 }}
-        />
-        <Bar dataKey="netPnl" isAnimationActive={false} maxBarSize={28}>
-          {data.map((entry) => (
-            <Cell
-              key={entry.date}
-              fill={entry.netPnl >= 0 ? t.profitFill : t.loss}
-              radius={(entry.netPnl >= 0 ? [4, 4, 0, 0] : [0, 0, 4, 4]) as unknown as number}
-            />
-          ))}
-        </Bar>
-      </BarChart>
-    </ResponsiveContainer>
+    <ChartFrame height={height}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart
+          key={String(privateMode)}
+          data={data}
+          margin={{ top: 8, right: 8, bottom: 0, left: 8 }}
+          barCategoryGap="20%"
+        >
+          <CartesianGrid stroke={t.gridline} strokeWidth={1} vertical={false} />
+          <XAxis
+            dataKey="date"
+            tick={{ fill: t.inkMuted, fontSize: 11 }}
+            tickLine={false}
+            axisLine={{ stroke: t.baseline }}
+            minTickGap={48}
+          />
+          <YAxis
+            tick={{ fill: t.inkMuted, fontSize: 11 }}
+            tickLine={false}
+            axisLine={false}
+            width={70}
+            tickFormatter={(value: number) =>
+              privateMode ? "••••" : fmtMoney(value).replace(".00", "")
+            }
+          />
+          <ReferenceLine y={0} stroke={t.baseline} />
+          <Tooltip
+            contentStyle={tooltipStyle(t)}
+            formatter={(value) => [privateMode ? "Hidden" : fmtMoney(Number(value)), "Net P&L"]}
+            cursor={{ fill: t.gridline, opacity: 0.4 }}
+          />
+          <Bar dataKey="netPnl" isAnimationActive={false} maxBarSize={28}>
+            {data.map((entry) => (
+              <Cell
+                key={entry.date}
+                fill={entry.netPnl >= 0 ? t.profitFill : t.loss}
+                radius={(entry.netPnl >= 0 ? [4, 4, 0, 0] : [0, 0, 4, 4]) as unknown as number}
+              />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </ChartFrame>
   );
 }

--- a/apps/web/src/components/charts/echart.tsx
+++ b/apps/web/src/components/charts/echart.tsx
@@ -58,8 +58,28 @@ export function EChart({
   }, []);
 
   useEffect(() => {
-    chartRef.current?.setOption(option, { notMerge: true });
+    const motion = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const apply = () =>
+      chartRef.current?.setOption(
+        {
+          ...option,
+          animation: !motion.matches,
+          animationDuration: 850,
+          animationDurationUpdate: 0,
+          animationEasing: "cubicInOut",
+        },
+        { notMerge: true },
+      );
+    apply();
+    motion.addEventListener("change", apply);
+    return () => motion.removeEventListener("change", apply);
   }, [option]);
 
-  return <div ref={hostRef} className={className} style={{ height, width: "100%" }} />;
+  return (
+    <div
+      ref={hostRef}
+      className={className}
+      style={{ height, width: "100%", overflow: "hidden", minWidth: 0 }}
+    />
+  );
 }

--- a/apps/web/src/components/charts/edge-radar.tsx
+++ b/apps/web/src/components/charts/edge-radar.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import { useState } from "react";
+
 import {
   PolarAngleAxis,
   PolarGrid,
+  PolarRadiusAxis,
   Radar,
   RadarChart,
   ResponsiveContainer,
@@ -10,6 +13,7 @@ import {
 } from "recharts";
 import type { EdgeScoreComponents } from "@luxalgo/journal-core";
 import { tooltipStyle, useVizTokens } from "./tokens";
+import { ChartFrame } from "./chart-frame";
 
 const LABELS: Record<keyof EdgeScoreComponents, string> = {
   winRate: "Win %",
@@ -26,29 +30,44 @@ export function EdgeRadar({
   height = 220,
 }: {
   components: EdgeScoreComponents;
-  height?: number;
+  height?: number | `${number}%`;
 }) {
   const t = useVizTokens();
+  const [radius, setRadius] = useState(48);
   if (!t) return <div style={{ height }} />;
   const data = (Object.keys(LABELS) as (keyof EdgeScoreComponents)[]).map((key) => ({
     metric: LABELS[key],
     value: Math.round(components[key]),
   }));
   return (
-    <ResponsiveContainer width="100%" height={height}>
-      <RadarChart data={data} outerRadius="72%">
-        <PolarGrid stroke={t.gridline} />
-        <PolarAngleAxis dataKey="metric" tick={{ fill: t.inkMuted, fontSize: 11 }} />
-        <Tooltip contentStyle={tooltipStyle(t)} formatter={(value) => [`${value}/100`, "Score"]} />
-        <Radar
-          dataKey="value"
-          stroke={t.brand}
-          fill={t.brand}
-          fillOpacity={0.28}
-          strokeWidth={2}
-          isAnimationActive={false}
-        />
-      </RadarChart>
-    </ResponsiveContainer>
+    <ChartFrame height={height}>
+      <ResponsiveContainer
+        width="100%"
+        height="100%"
+        onResize={(width, height) =>
+          setRadius(Math.max(20, Math.min(width / 2 - 84, height / 2 - 34)))
+        }
+      >
+        <RadarChart className="journal-edge-radar" data={data} outerRadius={radius}>
+          <PolarGrid stroke={t.gridline} />
+          <PolarRadiusAxis domain={[0, 100]} tick={false} axisLine={false} />
+          <PolarAngleAxis dataKey="metric" tick={{ fill: t.inkMuted, fontSize: 11 }} />
+          <Tooltip
+            cursor={false}
+            allowEscapeViewBox={{ x: false, y: false }}
+            contentStyle={tooltipStyle(t)}
+            formatter={(value) => [`${value}/100`, "Score"]}
+          />
+          <Radar
+            dataKey="value"
+            stroke={t.brand}
+            fill={t.brand}
+            fillOpacity={0.28}
+            strokeWidth={2}
+            isAnimationActive={false}
+          />
+        </RadarChart>
+      </ResponsiveContainer>
+    </ChartFrame>
   );
 }

--- a/apps/web/src/components/charts/equity-area.tsx
+++ b/apps/web/src/components/charts/equity-area.tsx
@@ -14,6 +14,7 @@ import {
 import { fmtMoney, fmtPercent } from "@/lib/utils";
 import { usePrivacy } from "../privacy";
 import { tooltipStyle, useVizTokens } from "./tokens";
+import { ChartFrame } from "./chart-frame";
 
 export interface EquityPointDatum {
   t: string;
@@ -44,71 +45,73 @@ export function EquityArea({
   const bottom = Math.min(0, ...data.map((point) => point.cumNetPnl));
   const zero = top === bottom ? 100 : (top / (top - bottom)) * 100;
   return (
-    <ResponsiveContainer width="100%" height={height}>
-      <AreaChart
-        key={String(privateMode)}
-        data={data}
-        margin={{ top: 8, right: 8, bottom: 0, left: 8 }}
-      >
-        <defs>
-          <linearGradient id={`${id}-line`} x1="0" y1="0" x2="0" y2="1">
-            <stop offset={`${zero}%`} stopColor={line} />
-            <stop offset={`${zero}%`} stopColor={t.loss} />
-          </linearGradient>
-          <linearGradient id={`${id}-fill`} x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stopColor={line} stopOpacity={0.3} />
-            <stop offset={`${zero}%`} stopColor={line} stopOpacity={0.035} />
-            <stop offset={`${zero}%`} stopColor={t.loss} stopOpacity={0.035} />
-            <stop offset="100%" stopColor={t.loss} stopOpacity={0.3} />
-          </linearGradient>
-        </defs>
-        <CartesianGrid stroke={t.gridline} strokeWidth={1} vertical={false} />
-        <XAxis
-          dataKey="t"
-          tick={{ fill: t.inkMuted, fontSize: 11 }}
-          tickLine={false}
-          axisLine={{ stroke: t.baseline }}
-          minTickGap={48}
-          tickFormatter={(value: string) => value.slice(0, 10)}
-        />
-        <YAxis
-          tick={{ fill: t.inkMuted, fontSize: 11 }}
-          tickLine={false}
-          axisLine={false}
-          width={70}
-          domain={[bottom, top === bottom ? 1 : top]}
-          tickFormatter={(value: number) =>
-            privateMode ? "••••" : formatValue(value).replace(".00", "")
-          }
-        />
-        <ReferenceLine y={0} stroke={t.baseline} />
-        <Tooltip
-          contentStyle={tooltipStyle(t)}
-          labelFormatter={(value) => String(value).slice(0, 10)}
-          formatter={(value) => [privateMode ? "Hidden" : formatValue(Number(value)), valueLabel]}
-          cursor={{ stroke: t.inkMuted, strokeDasharray: "3 3" }}
-        />
-        <Area
-          type="monotone"
-          dataKey="cumNetPnl"
-          stroke={bottom < 0 ? (top > 0 ? `url(#${id}-line)` : t.loss) : line}
-          strokeWidth={2}
-          fill={`url(#${id}-fill)`}
-          baseValue={0}
-          dot={false}
-          activeDot={({ cx, cy, payload }) => (
-            <circle
-              cx={cx}
-              cy={cy}
-              r={4}
-              fill={payload.cumNetPnl < 0 ? t.loss : line}
-              stroke={t.card}
-              strokeWidth={2}
-            />
-          )}
-          isAnimationActive={false}
-        />
-      </AreaChart>
-    </ResponsiveContainer>
+    <ChartFrame height={height}>
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart
+          key={String(privateMode)}
+          data={data}
+          margin={{ top: 8, right: 8, bottom: 0, left: 8 }}
+        >
+          <defs>
+            <linearGradient id={`${id}-line`} x1="0" y1="0" x2="0" y2="1">
+              <stop offset={`${zero}%`} stopColor={line} />
+              <stop offset={`${zero}%`} stopColor={t.loss} />
+            </linearGradient>
+            <linearGradient id={`${id}-fill`} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={line} stopOpacity={0.3} />
+              <stop offset={`${zero}%`} stopColor={line} stopOpacity={0.035} />
+              <stop offset={`${zero}%`} stopColor={t.loss} stopOpacity={0.035} />
+              <stop offset="100%" stopColor={t.loss} stopOpacity={0.3} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid stroke={t.gridline} strokeWidth={1} vertical={false} />
+          <XAxis
+            dataKey="t"
+            tick={{ fill: t.inkMuted, fontSize: 11 }}
+            tickLine={false}
+            axisLine={{ stroke: t.baseline }}
+            minTickGap={48}
+            tickFormatter={(value: string) => value.slice(0, 10)}
+          />
+          <YAxis
+            tick={{ fill: t.inkMuted, fontSize: 11 }}
+            tickLine={false}
+            axisLine={false}
+            width={70}
+            domain={[bottom, top === bottom ? 1 : top]}
+            tickFormatter={(value: number) =>
+              privateMode ? "••••" : formatValue(value).replace(".00", "")
+            }
+          />
+          <ReferenceLine y={0} stroke={t.baseline} />
+          <Tooltip
+            contentStyle={tooltipStyle(t)}
+            labelFormatter={(value) => String(value).slice(0, 10)}
+            formatter={(value) => [privateMode ? "Hidden" : formatValue(Number(value)), valueLabel]}
+            cursor={{ stroke: t.inkMuted, strokeDasharray: "3 3" }}
+          />
+          <Area
+            type="monotone"
+            dataKey="cumNetPnl"
+            stroke={bottom < 0 ? (top > 0 ? `url(#${id}-line)` : t.loss) : line}
+            strokeWidth={2}
+            fill={`url(#${id}-fill)`}
+            baseValue={0}
+            dot={false}
+            activeDot={({ cx, cy, payload }) => (
+              <circle
+                cx={cx}
+                cy={cy}
+                r={4}
+                fill={payload.cumNetPnl < 0 ? t.loss : line}
+                stroke={t.card}
+                strokeWidth={2}
+              />
+            )}
+            isAnimationActive={false}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </ChartFrame>
   );
 }

--- a/apps/web/src/components/charts/gauge.tsx
+++ b/apps/web/src/components/charts/gauge.tsx
@@ -24,7 +24,7 @@ export function Gauge({
   if (!t) return <div style={{ width: size, height: size / 2 + 18 }} />;
   return (
     <div
-      className="flex flex-col items-center"
+      className="journal-gauge flex min-w-0 flex-col items-center"
       role="img"
       aria-label={`${label}: ${value === null ? "no data" : `${(ratio * 100).toFixed(1)}%`}`}
     >
@@ -46,6 +46,7 @@ export function Gauge({
           d={`M 6 ${size / 2 + 2} A ${radius} ${radius} 0 0 1 ${size - 6} ${size / 2 + 2}`}
           fill="none"
           stroke={`url(#${gradientId})`}
+          className="journal-gauge-value"
           strokeWidth={8}
           strokeLinecap="round"
           strokeDasharray={`${circumference * ratio} ${circumference}`}

--- a/apps/web/src/components/charts/relative-drawdown-bars.tsx
+++ b/apps/web/src/components/charts/relative-drawdown-bars.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import type { RelativeDrawdownPoint } from "@luxalgo/journal-core";
+import { fmtPercent } from "@/lib/utils";
+import { tooltipStyle, useVizTokens } from "./tokens";
+import { ChartFrame } from "./chart-frame";
+
+export function RelativeDrawdownBars({ data }: { data: RelativeDrawdownPoint[] }) {
+  const tokens = useVizTokens();
+  const chartData = data.map((point) => ({
+    t: point.t,
+    drawdownPct: point.drawdownPct === null ? null : -point.drawdownPct,
+  }));
+  const available = chartData.filter(
+    (point): point is { t: string; drawdownPct: number } => point.drawdownPct !== null,
+  );
+  const maxDrawdown = Math.max(0, ...available.map((point) => Math.abs(point.drawdownPct)));
+
+  if (!tokens) return <div className="h-24" />;
+
+  return (
+    <div className="mt-2 border-t pt-3">
+      <div className="mb-1 flex items-center justify-between gap-3 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+        <span>Relative drawdown</span>
+        <span className="tnum text-loss">
+          {available.length === 0 ? "Initial balance required" : `Max −${fmtPercent(maxDrawdown)}`}
+        </span>
+      </div>
+      {available.length === 0 ? (
+        <div className="flex h-20 items-center justify-center text-xs text-muted-foreground">
+          Set an initial balance to chart relative drawdown.
+        </div>
+      ) : (
+        <ChartFrame height={96}>
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={chartData}
+              margin={{ top: 2, right: 8, bottom: 0, left: 8 }}
+              barCategoryGap={0}
+            >
+              <CartesianGrid stroke={tokens.gridline} strokeWidth={1} vertical={false} />
+              <XAxis
+                dataKey="t"
+                tick={false}
+                tickLine={false}
+                axisLine={{ stroke: tokens.baseline }}
+                height={8}
+              />
+              <YAxis
+                tick={{ fill: tokens.inkMuted, fontSize: 10 }}
+                tickLine={false}
+                axisLine={false}
+                width={70}
+                domain={[-Math.max(maxDrawdown, 0.01), 0]}
+                tickFormatter={(value: number) => fmtPercent(Math.abs(value), 0)}
+                tickCount={3}
+              />
+              <Tooltip
+                contentStyle={tooltipStyle(tokens)}
+                labelFormatter={(value) => String(value).slice(0, 10)}
+                formatter={(value) => [fmtPercent(Math.abs(Number(value)), 2), "Relative drawdown"]}
+                cursor={{ fill: tokens.loss, fillOpacity: 0.08 }}
+              />
+              <Bar
+                dataKey="drawdownPct"
+                fill={tokens.loss}
+                fillOpacity={0.82}
+                isAnimationActive={false}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartFrame>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/charts/rolling-trade-chart.tsx
+++ b/apps/web/src/components/charts/rolling-trade-chart.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { PerformanceTrends } from "@/lib/performance-trends";
+import { fmtMoney, fmtPercent } from "@/lib/utils";
+import { usePrivacy } from "../privacy";
+import { ChartFrame } from "./chart-frame";
+import { tooltipStyle, useVizTokens } from "./tokens";
+
+export function RollingTradeChart({
+  data,
+  metric,
+  reference,
+  currency,
+  timeZone,
+}: {
+  data: PerformanceTrends["points"];
+  metric: "winRate" | "avgNetPnl";
+  reference: number;
+  currency: string;
+  timeZone: string;
+}) {
+  const tokens = useVizTokens();
+  const privacy = usePrivacy();
+  const rate = metric === "winRate";
+  const format = (value: number) =>
+    rate ? fmtPercent(value, 0) : privacy ? "••••" : fmtMoney(value, currency);
+  if (!tokens) return <div className="h-60" />;
+  return (
+    <ChartFrame height={240}>
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart
+          data={data}
+          margin={{ top: 12, right: 14, bottom: 4, left: 0 }}
+          aria-label={`${rate ? "Win rate" : "Average net P&L"} over 20-trade windows. Exact values and links follow below.`}
+        >
+          <CartesianGrid stroke={tokens.gridline} vertical={false} />
+          <XAxis
+            dataKey="sequence"
+            type="number"
+            domain={["dataMin", "dataMax"]}
+            allowDecimals={false}
+            tickFormatter={(value: number) => `#${value}`}
+            tick={{ fill: tokens.inkMuted, fontSize: 11 }}
+            tickLine={false}
+            axisLine={{ stroke: tokens.baseline }}
+            minTickGap={24}
+          />
+          <YAxis
+            width={rate ? 48 : 80}
+            domain={
+              rate ? [0, 1] : [(min: number) => Math.min(0, min), (max: number) => Math.max(0, max)]
+            }
+            tickFormatter={format}
+            tick={{ fill: tokens.inkMuted, fontSize: 11 }}
+            tickLine={false}
+            axisLine={false}
+          />
+          {!rate && <ReferenceLine y={0} stroke={tokens.baseline} />}
+          <ReferenceLine
+            y={reference}
+            stroke={tokens.inkMuted}
+            strokeDasharray="4 4"
+            ifOverflow="extendDomain"
+          />
+          <Tooltip
+            contentStyle={tooltipStyle(tokens)}
+            labelFormatter={(label) => {
+              const point = data.find((point) => point.sequence === Number(label));
+              return `Trade #${label}${point ? ` · ${new Intl.DateTimeFormat("en", { timeZone, month: "short", day: "numeric", year: "numeric" }).format(new Date(point.closedAt))}` : ""}`;
+            }}
+            formatter={(value) => [format(Number(value)), "Last 20 trades"]}
+          />
+          <Line
+            dataKey={metric}
+            type="linear"
+            stroke={tokens.brand}
+            strokeWidth={2}
+            dot={false}
+            activeDot={{ r: 4 }}
+            isAnimationActive={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </ChartFrame>
+  );
+}

--- a/apps/web/src/components/charts/time-heatmap.tsx
+++ b/apps/web/src/components/charts/time-heatmap.tsx
@@ -65,7 +65,11 @@ export function TimeHeatmap({
         trigger: "axis",
         backgroundColor: t.card,
         borderColor: t.border,
-        textStyle: { color: t.foreground, fontSize: 12 },
+        borderWidth: 1,
+        padding: [12, 14],
+        extraCssText:
+          "border-radius:12px;box-shadow:0 12px 32px rgba(0,0,0,.18),0 2px 8px rgba(0,0,0,.1);line-height:1.6;",
+        textStyle: { color: t.foreground, fontSize: 13 },
       },
       axisPointer: { link: [{ xAxisIndex: "all" }] },
       xAxis: [

--- a/apps/web/src/components/charts/tokens.ts
+++ b/apps/web/src/components/charts/tokens.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 
 export interface VizTokens {
   surface: string;
@@ -46,22 +46,44 @@ export const readVizTokens = (): VizTokens => {
  * paints to canvas, which can't — so every chart resolves tokens through this
  * hook and re-resolves when the theme class flips.
  */
-export const useVizTokens = (): VizTokens | null => {
-  const [tokens, setTokens] = useState<VizTokens | null>(null);
-  useEffect(() => {
-    setTokens(readVizTokens());
-    const observer = new MutationObserver(() => setTokens(readVizTokens()));
+let tokens: VizTokens | null = null;
+const listeners = new Set<() => void>();
+let observer: MutationObserver | null = null;
+const getTokens = () => tokens;
+const getServerTokens = () => null;
+function subscribeTokens(listener: () => void) {
+  listeners.add(listener);
+  if (!observer) {
+    const read = () => {
+      const next = readVizTokens();
+      if (JSON.stringify(next) === JSON.stringify(tokens)) return;
+      tokens = next;
+      listeners.forEach((notify) => notify());
+    };
+    observer = new MutationObserver(read);
     observer.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
-    return () => observer.disconnect();
-  }, []);
-  return tokens;
-};
+    read();
+  }
+  return () => {
+    listeners.delete(listener);
+    if (!listeners.size) {
+      observer?.disconnect();
+      observer = null;
+      tokens = null;
+    }
+  };
+}
+/** Every mounted chart shares one theme observer and one computed-style read. */
+export const useVizTokens = (): VizTokens | null =>
+  useSyncExternalStore(subscribeTokens, getTokens, getServerTokens);
 
 export const tooltipStyle = (t: VizTokens): React.CSSProperties => ({
   background: t.card,
   border: `1px solid ${t.border}`,
-  borderRadius: 8,
-  fontSize: 12,
+  borderRadius: 12,
+  padding: "12px 14px",
+  fontSize: 13,
+  lineHeight: 1.6,
   color: t.foreground,
-  boxShadow: "0 4px 12px rgba(0,0,0,0.25)",
+  boxShadow: "0 12px 32px rgba(0,0,0,0.18), 0 2px 8px rgba(0,0,0,0.1)",
 });

--- a/apps/web/src/components/charts/trade-scatter.tsx
+++ b/apps/web/src/components/charts/trade-scatter.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import {
+  CartesianGrid,
+  ReferenceLine,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+  ZAxis,
+} from "recharts";
+import { useMemo } from "react";
+import {
+  clockLabel,
+  type PlottedTrade,
+  type TradeXAxis,
+  type TradeYAxis,
+} from "@/lib/trade-explorer";
+import { fmtMoney } from "@/lib/utils";
+import { usePrivacy } from "../privacy";
+import { ChartFrame } from "./chart-frame";
+import { tooltipStyle, useVizTokens } from "./tokens";
+
+export function TradeScatter({
+  points,
+  x,
+  y,
+  currency,
+  timeZone,
+  onSelect,
+}: {
+  points: PlottedTrade[];
+  x: TradeXAxis;
+  y: TradeYAxis;
+  currency: string;
+  timeZone: string;
+  onSelect: (point: PlottedTrade) => void;
+}) {
+  const tokens = useVizTokens();
+  const privateMode = usePrivacy();
+  const groups = useMemo(
+    () => [
+      points.filter((p) => p.y > 0),
+      points.filter((p) => p.y < 0),
+      points.filter((p) => p.y === 0),
+    ],
+    [points],
+  );
+  const date = useMemo(
+    () => new Intl.DateTimeFormat("en", { timeZone, dateStyle: "medium", timeStyle: "short" }),
+    [timeZone],
+  );
+  const yLabel = (n: number) =>
+    y === "realizedR" ? `${n.toFixed(2)}R` : privateMode ? "••••" : fmtMoney(n, currency);
+  if (!tokens) return <div className="h-80" />;
+  return (
+    <ChartFrame height={340}>
+      <ResponsiveContainer width="100%" height="100%">
+        <ScatterChart
+          margin={{ top: 12, right: 24, bottom: 8, left: 0 }}
+          aria-label="Individual trade outcomes. Select a point to inspect; all trades also have links in the table below."
+        >
+          <CartesianGrid stroke={tokens.gridline} />
+          <XAxis
+            type="number"
+            dataKey="x"
+            domain={x === "entryMinute" ? [0, 1440] : [0, "auto"]}
+            ticks={x === "entryMinute" ? [0, 360, 720, 1080, 1440] : undefined}
+            minTickGap={24}
+            tickFormatter={(n: number) =>
+              x === "entryMinute"
+                ? clockLabel(n)
+                : n.toLocaleString(undefined, { maximumFractionDigits: 1, notation: "compact" })
+            }
+            tick={{ fill: tokens.inkMuted, fontSize: 11 }}
+            tickLine={false}
+            axisLine={{ stroke: tokens.baseline }}
+          />
+          <YAxis
+            type="number"
+            dataKey="y"
+            width={82}
+            domain={[(min: number) => Math.min(min, 0), (max: number) => Math.max(max, 0)]}
+            tickFormatter={yLabel}
+            tick={{ fill: tokens.inkMuted, fontSize: 11 }}
+            tickLine={false}
+            axisLine={false}
+          />
+          <ZAxis range={[44, 44]} />
+          <ReferenceLine y={0} stroke={tokens.inkMuted} />
+          <Tooltip
+            cursor={{ strokeDasharray: "3 3", stroke: tokens.inkMuted }}
+            content={({ active, payload }) => {
+              const point = payload?.[0]?.payload as PlottedTrade | undefined;
+              return active && point ? (
+                <div style={{ ...tooltipStyle(tokens), maxWidth: 230, overflowWrap: "anywhere" }}>
+                  <p className="font-medium">
+                    {point.symbol} · {point.direction}
+                  </p>
+                  <p className="text-xs">Closed {date.format(new Date(point.closedAt))}</p>
+                  <p>
+                    {x === "durationMinutes"
+                      ? `${point.x.toLocaleString(undefined, { maximumFractionDigits: 2 })} minutes`
+                      : `${clockLabel(point.x)} entry`}
+                  </p>
+                  <p>
+                    {y === "netPnl" ? "Net P&L" : "Realized R"}: {yLabel(point.y)}
+                  </p>
+                  <p className="text-xs text-muted-foreground">Select to inspect this trade</p>
+                </div>
+              ) : null;
+            }}
+          />
+          {groups.map((data, index) => (
+            <Scatter
+              key={index}
+              data={data}
+              name={["Positive net P&L", "Negative net P&L", "Zero net P&L"][index]}
+              shape="circle"
+              fill={[tokens.profitFill, tokens.loss, tokens.inkMuted][index]}
+              fillOpacity={0.7}
+              stroke={[tokens.profit, tokens.loss, tokens.inkMuted][index]}
+              strokeWidth={1}
+              isAnimationActive={false}
+              onClick={(value: { payload?: PlottedTrade }) => {
+                if (value.payload) onSelect(value.payload);
+              }}
+              cursor="pointer"
+            />
+          ))}
+        </ScatterChart>
+      </ResponsiveContainer>
+    </ChartFrame>
+  );
+}

--- a/apps/web/src/components/dashboard-layout.tsx
+++ b/apps/web/src/components/dashboard-layout.tsx
@@ -1,8 +1,9 @@
 "use client";
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import {
   DndContext,
   DragOverlay,
+  AutoScrollActivator,
   KeyboardSensor,
   MeasuringStrategy,
   PointerSensor,
@@ -23,13 +24,16 @@ import { DashboardCustomizer } from "@/components/dashboard-customizer";
 import { DashboardSavedLayouts } from "@/components/dashboard-saved-layouts";
 import {
   DASHBOARD_LAYOUT_KEY,
+  balancedDashboardSpans,
   moveDashboardCard,
   normalizeArrangement,
   readDashboardPreferences,
   visibleCardIds,
   type DashboardArrangement,
+  type DashboardCardSize,
   type DashboardPreferences,
 } from "@/lib/dashboard-layout";
+import { isInsideDashboardReorderZone } from "@/lib/dashboard-drag";
 import {
   DASHBOARD_MOVE_EASING,
   DashboardDragPreview,
@@ -43,7 +47,8 @@ import {
 interface Widget {
   id: string;
   label: string;
-  size: "small" | "medium" | "wide" | "full";
+  size: DashboardCardSize;
+  layoutGroup: "summary" | "visuals" | "detail" | "secondary" | "full";
   content: ReactNode;
 }
 const collisionDetection: CollisionDetection = (args) =>
@@ -74,6 +79,7 @@ export function DashboardLayout({ widgets }: { widgets: Widget[] }) {
   const [draft, setDraft] = useState<DashboardArrangement | null>(null);
   const draftRef = useRef<DashboardArrangement | null>(null);
   const [snapshot, setSnapshot] = useState<DashboardCardSnapshot | null>(null);
+  const snapshotRef = useRef<DashboardCardSnapshot | null>(null);
   const dragInput = useDashboardDragInput();
   const lastReorder = useRef<{ x: number; y: number } | null>(null);
   const reducedMotion = useReducedDashboardMotion();
@@ -142,9 +148,31 @@ export function DashboardLayout({ widgets }: { widgets: Widget[] }) {
 
   const current = normalizeArrangement(draft ?? state.current, ids);
   const visible = visibleCardIds(current);
-  const { gridRef, stageRef, captureLayout, rendered, exiting } = useDashboardGridMotion(visible);
+  const { gridRef, stageRef, captureLayout, rendered, exiting } = useDashboardGridMotion(
+    visible,
+    ready,
+  );
   const hiddenCount = ids.length - visible.length;
   const byId = new Map(widgets.map((widget) => [widget.id, widget]));
+  const visibleWidgets = visible.map((id) => byId.get(id)!);
+  const compactSpans = balancedDashboardSpans(visibleWidgets, 2, {
+    small: 1,
+    medium: 2,
+    wide: 2,
+    full: 2,
+  });
+  const tabletSpans = balancedDashboardSpans(visibleWidgets, 6, {
+    small: 2,
+    medium: 2,
+    wide: 4,
+    full: 6,
+  });
+  const desktopSpans = balancedDashboardSpans(visibleWidgets, 15, {
+    small: 3,
+    medium: 5,
+    wide: 10,
+    full: 15,
+  });
   const label = (id: string | number) => byId.get(String(id))?.label ?? "Card";
 
   function move(from: string, to: string) {
@@ -167,6 +195,7 @@ export function DashboardLayout({ widgets }: { widgets: Widget[] }) {
     const surface = card?.querySelector<HTMLElement>("[data-dashboard-surface]");
     const preview = surface ? snapshotDashboardCard(surface, activatorEvent) : null;
     dragInput.start(preview);
+    snapshotRef.current = preview;
     setSnapshot(preview);
     draftRef.current = normalizeArrangement(stateRef.current.current, ids);
     setDraft(draftRef.current);
@@ -177,10 +206,16 @@ export function DashboardLayout({ widgets }: { widgets: Widget[] }) {
     if (!draftRef.current) return;
     dragInput.moveKeyboard(delta);
     if (!over || active.id === over.id) return;
+    const pointerOrigin = snapshotRef.current?.pointer;
+    if (pointerOrigin) {
+      const movement = dragInput.point.current;
+      const pointer = { x: pointerOrigin.x + movement.x, y: pointerOrigin.y + movement.y };
+      if (!isInsideDashboardReorderZone(pointer, over.rect)) return;
+    }
     // Reflow can move another card beneath a stationary pointer. Only an actual
     // movement may trigger the next reorder, so holding still never oscillates.
     const last = lastReorder.current;
-    if (last && Math.hypot(delta.x - last.x, delta.y - last.y) < 8) return;
+    if (last && Math.hypot(delta.x - last.x, delta.y - last.y) < 24) return;
     const next = moveDashboardCard(draftRef.current, String(active.id), String(over.id));
     if (next === draftRef.current) return;
     captureLayout();
@@ -190,6 +225,7 @@ export function DashboardLayout({ widgets }: { widgets: Widget[] }) {
   }
   function clearDrag() {
     dragInput.stop();
+    snapshotRef.current = null;
     draftRef.current = null;
     setDraft(null);
     setActiveId(null);
@@ -314,7 +350,13 @@ export function DashboardLayout({ widgets }: { widgets: Widget[] }) {
         key={dragSession}
         sensors={sensors}
         collisionDetection={collisionDetection}
-        measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
+        autoScroll={{
+          activator: AutoScrollActivator.Pointer,
+          acceleration: 4,
+          interval: 12,
+          threshold: { x: 0.05, y: 0.07 },
+        }}
+        measuring={{ droppable: { strategy: MeasuringStrategy.WhileDragging } }}
         onDragStart={startDrag}
         onDragMove={previewDrag}
         onDragOver={previewDrag}
@@ -346,6 +388,11 @@ export function DashboardLayout({ widgets }: { widgets: Widget[] }) {
                 <SortableCard
                   key={id}
                   widget={byId.get(id)!}
+                  responsiveSpans={{
+                    compact: compactSpans[id]!,
+                    tablet: tabletSpans[id]!,
+                    desktop: desktopSpans[id]!,
+                  }}
                   edit={edit}
                   exiting={exiting.has(id)}
                   first={visible.indexOf(id) === 0}
@@ -372,6 +419,7 @@ export function DashboardLayout({ widgets }: { widgets: Widget[] }) {
 
 function SortableCard({
   widget,
+  responsiveSpans,
   edit,
   exiting,
   first,
@@ -379,6 +427,7 @@ function SortableCard({
   onMove,
 }: {
   widget: Widget;
+  responsiveSpans: { compact: number; tablet: number; desktop: number };
   edit: boolean;
   exiting: boolean;
   first: boolean;
@@ -401,6 +450,13 @@ function SortableCard({
       inert={exiting || undefined}
       aria-label={widget.label}
       className="dashboard-grid-card relative flex min-w-0 flex-col rounded-xl"
+      style={
+        {
+          "--dashboard-span-compact": responsiveSpans.compact,
+          "--dashboard-span-tablet": responsiveSpans.tablet,
+          "--dashboard-span-desktop": responsiveSpans.desktop,
+        } as CSSProperties
+      }
     >
       <div
         data-dashboard-surface

--- a/apps/web/src/components/dashboard-motion.tsx
+++ b/apps/web/src/components/dashboard-motion.tsx
@@ -39,7 +39,7 @@ interface CardAnimation {
 }
 
 /** Keep departing cards alive outside the grid until their shrink animation finishes. */
-export function useDashboardGridMotion(visible: string[]) {
+export function useDashboardGridMotion(visible: string[], ready: boolean) {
   const orderKey = JSON.stringify(visible);
   const gridRef = useRef<HTMLDivElement>(null);
   const stageRef = useRef<HTMLDivElement>(null);
@@ -291,7 +291,7 @@ export function useDashboardGridMotion(visible: string[]) {
     });
     observer.observe(grid);
     return () => observer.disconnect();
-  });
+  }, [ready]);
 
   return { gridRef, stageRef, captureLayout, rendered, exiting };
 }

--- a/apps/web/src/components/filter-bar.tsx
+++ b/apps/web/src/components/filter-bar.tsx
@@ -1,10 +1,16 @@
 "use client";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { dayKeyOf, FILTER_KEYS, readFilters, type AnalysisFilters } from "@luxalgo/journal-core";
 import { useApi } from "@/lib/use-api";
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { FilterFields } from "./filter-fields";
 import { SlidersHorizontal } from "lucide-react";
 import { AccountSelector } from "./account-selector";
@@ -47,6 +53,7 @@ export function FilterBar({ title, actions }: { title: string; actions?: React.R
     pathname.startsWith("/journal/");
   const [open, setOpen] = useState(false),
     [draft, setDraft] = useState<AnalysisFilters>({});
+  const filterTitle = useRef<HTMLHeadingElement>(null);
   const count = Object.keys(filters.values).filter((k) => !["from", "to"].includes(k)).length;
   const apply = () => {
     const next = new URLSearchParams(params.toString());
@@ -85,6 +92,7 @@ export function FilterBar({ title, actions }: { title: string; actions?: React.R
             <Button
               variant="outline"
               size="sm"
+              title="Filter by dates, symbols, strategy, outcome, and more. All selected conditions must match."
               onClick={() => {
                 setDraft(filters.values);
                 setOpen(true);
@@ -102,20 +110,36 @@ export function FilterBar({ title, actions }: { title: string; actions?: React.R
         )}
       </div>
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-3xl">
-          <DialogHeader>
-            <DialogTitle>Filter your journal</DialogTitle>
+        <DialogContent
+          className="journal-filter-dialog sm:max-w-3xl"
+          onOpenAutoFocus={(event) => {
+            event.preventDefault();
+            filterTitle.current?.focus();
+          }}
+        >
+          <DialogHeader className="journal-filter-heading">
+            <DialogTitle ref={filterTitle} tabIndex={-1} className="outline-none">
+              Filter your journal
+            </DialogTitle>
+            <DialogDescription className="journal-filter-description">
+              Times use {filters.timeZone}. Dates use the closing day, or opening day for open
+              trades. All selected conditions must match.
+            </DialogDescription>
           </DialogHeader>
-          <p className="text-xs text-muted-foreground">
-            Times use {filters.timeZone}. Dates use the closing day, or opening day for open trades.
-            All selected conditions must match.
-          </p>
-          <FilterFields value={draft} onChange={setDraft} />
-          <div className="flex justify-between">
-            <Button variant="ghost" onClick={() => setDraft({})}>
+          <div className="journal-filter-body">
+            <FilterFields value={draft} onChange={setDraft} />
+          </div>
+          <div className="journal-filter-footer flex items-center justify-between gap-3">
+            <Button
+              variant="ghost"
+              className="text-muted-foreground hover:text-foreground"
+              onClick={() => setDraft({})}
+            >
               Clear filters
             </Button>
-            <Button onClick={apply}>Apply filters</Button>
+            <Button className="min-w-28" onClick={apply}>
+              Apply filters
+            </Button>
           </div>
         </DialogContent>
       </Dialog>

--- a/apps/web/src/components/filter-fields.tsx
+++ b/apps/web/src/components/filter-fields.tsx
@@ -1,12 +1,47 @@
 "use client";
+import { OptionSelect } from "@/components/ui/option-select";
+import { Checkbox } from "@/components/ui/checkbox";
+
 import type { AnalysisFilters, FilterKey } from "@luxalgo/journal-core";
 import { useApi } from "@/lib/use-api";
 import { MonetaryField } from "./privacy";
+import { ChevronDown, CircleHelp } from "lucide-react";
+import { HoverHint } from "./ui/tooltip";
+import { DatePicker } from "./ui/date-picker";
+const FIELD_HINTS: Record<string, string> = {
+  From: "First included date. Closed trades use their closing day; open trades use their opening day.",
+  To: "Last included date. Dates follow the journal time zone.",
+  Strategy: "Include trades assigned to this playbook. All includes trades without a playbook.",
+  "Symbols (comma-separated)":
+    "Include these symbols. Separate multiple symbols with commas, for example AAPL, NVDA.",
+  "Exclude symbols": "Hide these symbols from the results. Separate multiple symbols with commas.",
+  "Required tags (comma-separated)":
+    "Filter by tags recorded on your trades. Separate multiple tags with commas.",
+  "Required mistakes":
+    "Filter by recorded trading mistakes. Separate multiple mistakes with commas.",
+  "Review status": "Find trades you have marked reviewed, or those still awaiting review.",
+  "Realized R": "Trade profit or loss expressed as a multiple of the trade's initial risk.",
+  "Planned R": "The planned reward relative to the trade's initial risk.",
+  "Minutes held": "Time between opening and closing a trade, measured in minutes.",
+};
 export const fieldClass = "h-9 w-full min-w-0 rounded-md border bg-background px-2 text-sm";
 export function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
-    <label className="grid min-w-0 gap-1 text-xs text-muted-foreground">
-      {label}
+    <label className="journal-filter-field grid min-w-0 gap-1 text-xs text-muted-foreground">
+      <span className="flex items-center gap-1.5">
+        {label}
+        {FIELD_HINTS[label.split(" · ")[0]!] && (
+          <HoverHint heading={label} content={FIELD_HINTS[label.split(" · ")[0]!]}>
+            <span
+              tabIndex={0}
+              aria-label={`About ${label}`}
+              className="inline-flex cursor-help rounded-sm text-muted-foreground/70 outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <CircleHelp aria-hidden="true" className="h-3 w-3" />
+            </span>
+          </HoverHint>
+        )}
+      </span>
       {children}
     </label>
   );
@@ -28,35 +63,45 @@ export function FilterFields({
   const input = (key: FilterKey, label: string, type = "text") => (
     <Field key={key} label={label}>
       <MonetaryField sensitive={/^(entry|exit|pnl)(Min|Max)$/.test(key)}>
-        <input
-          className={fieldClass}
-          aria-label={label}
-          type={type}
-          step={type === "number" ? "any" : undefined}
-          value={value[key] ?? ""}
-          onChange={(e) => set(key, e.target.value)}
-        />
+        {type === "date" ? (
+          <DatePicker
+            value={value[key] ?? ""}
+            onValueChange={(next) => set(key, next)}
+            label={label}
+          />
+        ) : (
+          <input
+            className={fieldClass}
+            aria-label={label}
+            type={type}
+            step={type === "number" ? "any" : undefined}
+            value={value[key] ?? ""}
+            onChange={(e) => set(key, e.target.value)}
+          />
+        )}
       </MonetaryField>
     </Field>
   );
   const select = (key: FilterKey, label: string, choices: [string, string][]) => (
     <Field key={key} label={label}>
-      <select
-        className={fieldClass}
-        value={value[key] ?? ""}
-        onChange={(e) => set(key, e.target.value)}
-      >
-        <option value="">All</option>
-        {choices.map(([v, l]) => (
-          <option key={v} value={v}>
-            {l}
-          </option>
-        ))}
-      </select>
+      <span className="journal-filter-select relative block min-w-0">
+        <OptionSelect
+          className={fieldClass}
+          value={value[key] ?? ""}
+          onValueChange={(next) => set(key, next)}
+        >
+          <option value="">All</option>
+          {choices.map(([v, l]) => (
+            <option key={v} value={v}>
+              {l}
+            </option>
+          ))}
+        </OptionSelect>
+      </span>
     </Field>
   );
   return (
-    <div className="space-y-4">
+    <div className="journal-filter-fields space-y-5">
       <div className="grid grid-cols-1 gap-3 min-[420px]:grid-cols-2 md:grid-cols-3">
         {input("from", "From", "date")}
         {input("to", "To", "date")}
@@ -90,7 +135,7 @@ export function FilterFields({
           ["equity", "futures", "forex", "option", "crypto", "cfd", "other"].map((v) => [v, v]),
         )}
       </div>
-      <fieldset className="rounded-md border p-3">
+      <fieldset className="journal-filter-accounts rounded-lg border p-3">
         <legend className="px-1 text-xs text-muted-foreground">
           Accounts · none selected means all
         </legend>
@@ -98,13 +143,12 @@ export function FilterFields({
           {accounts?.accounts
             .filter((a) => !a.archivedAt)
             .map((a) => (
-              <label key={a.id} className="flex items-center gap-2 text-xs">
-                <input
-                  type="checkbox"
+              <label key={a.id} className="journal-filter-choice flex items-center gap-2 text-xs">
+                <Checkbox
                   checked={(value.accounts ?? "").split(",").includes(a.id)}
-                  onChange={(e) => {
+                  onCheckedChange={(checked) => {
                     const ids = new Set((value.accounts ?? "").split(",").filter(Boolean));
-                    if (e.target.checked) ids.add(a.id);
+                    if (checked === true) ids.add(a.id);
                     else ids.delete(a.id);
                     set("accounts", [...ids].join(","));
                   }}
@@ -114,9 +158,12 @@ export function FilterFields({
             ))}
         </div>
       </fieldset>
-      <details>
-        <summary className="cursor-pointer text-sm">Size, price, risk and time</summary>
-        <div className="mt-3 grid grid-cols-1 gap-3 min-[420px]:grid-cols-2 md:grid-cols-4">
+      <details className="journal-filter-advanced">
+        <summary className="flex cursor-pointer items-center justify-between gap-3 text-sm">
+          <span>Size, price, risk and time</span>
+          <ChevronDown aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground" />
+        </summary>
+        <div className="journal-filter-advanced-grid mt-3 grid grid-cols-1 gap-3 min-[420px]:grid-cols-2 md:grid-cols-4">
           {(
             [
               ["quantity", "Total entry quantity"],
@@ -137,15 +184,14 @@ export function FilterFields({
           {input("exitAfter", "Exit after", "time")}
           {input("exitBefore", "Exit before", "time")}
         </div>
-        <div className="mt-3 flex flex-wrap gap-3">
+        <div className="journal-filter-weekdays mt-3 flex flex-wrap gap-2">
           {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((day, i) => (
-            <label key={day} className="flex gap-1 text-xs">
-              <input
-                type="checkbox"
+            <label key={day} className="journal-filter-choice flex items-center gap-2 text-xs">
+              <Checkbox
                 checked={(value.weekdays ?? "").split(",").includes(String(i))}
-                onChange={(e) => {
+                onCheckedChange={(checked) => {
                   const days = new Set((value.weekdays ?? "").split(",").filter(Boolean));
-                  if (e.target.checked) days.add(String(i));
+                  if (checked === true) days.add(String(i));
                   else days.delete(String(i));
                   set("weekdays", [...days].join(","));
                 }}

--- a/apps/web/src/components/journal-default-settings.tsx
+++ b/apps/web/src/components/journal-default-settings.tsx
@@ -1,4 +1,6 @@
 "use client";
+import { OptionSelect } from "@/components/ui/option-select";
+
 import { MonetaryField } from "./privacy";
 import { useEffect, useState } from "react";
 import { useApi, postJson } from "@/lib/use-api";
@@ -22,10 +24,10 @@ export function JournalDefaultSettings() {
   const matchFields = (r: FeeRule | RiskRule, update: (r: FeeRule | RiskRule) => void) => (
     <>
       <Field label="Account">
-        <select
+        <OptionSelect
           className={fieldClass}
           value={r.accountId}
-          onChange={(e) => update({ ...r, accountId: e.target.value })}
+          onValueChange={(next) => update({ ...r, accountId: next })}
         >
           <option value="">All accounts</option>
           {accounts?.accounts.map((a) => (
@@ -33,7 +35,7 @@ export function JournalDefaultSettings() {
               {a.name}
             </option>
           ))}
-        </select>
+        </OptionSelect>
       </Field>
       <Field label="Symbol (blank = all)">
         <input
@@ -70,16 +72,16 @@ export function JournalDefaultSettings() {
             </MonetaryField>
           </Field>
           <Field label="Range unit">
-            <select
+            <OptionSelect
               className={fieldClass}
               value={draft.breakevenMode}
-              onChange={(e) =>
-                setDraft({ ...draft, breakevenMode: e.target.value as "money" | "percent" })
+              onValueChange={(next) =>
+                setDraft({ ...draft, breakevenMode: next as "money" | "percent" })
               }
             >
               <option value="money">Account currency</option>
               <option value="percent">% of entry notional</option>
-            </select>
+            </OptionSelect>
           </Field>
         </div>
         <p className="text-xs text-muted-foreground">
@@ -116,14 +118,14 @@ export function JournalDefaultSettings() {
                     </MonetaryField>
                   </Field>
                   <Field label="Charge per">
-                    <select
+                    <OptionSelect
                       className={fieldClass}
                       value={r.mode}
-                      onChange={(e) => update({ ...r, mode: e.target.value as FeeRule["mode"] })}
+                      onValueChange={(next) => update({ ...r, mode: next as FeeRule["mode"] })}
                     >
                       <option value="execution">Execution</option>
                       <option value="unit">Unit / contract</option>
-                    </select>
+                    </OptionSelect>
                   </Field>
                 </div>
                 <Button
@@ -201,14 +203,14 @@ export function JournalDefaultSettings() {
                     </MonetaryField>
                   </Field>
                   <Field label="Distance unit">
-                    <select
+                    <OptionSelect
                       className={fieldClass}
                       value={r.mode}
-                      onChange={(e) => update({ ...r, mode: e.target.value as RiskRule["mode"] })}
+                      onValueChange={(next) => update({ ...r, mode: next as RiskRule["mode"] })}
                     >
                       <option value="price">Price points</option>
                       <option value="percent">% of entry price</option>
-                    </select>
+                    </OptionSelect>
                   </Field>
                 </div>
                 <Button

--- a/apps/web/src/components/page-transition.tsx
+++ b/apps/web/src/components/page-transition.tsx
@@ -1,131 +1,32 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useRef, type ReactNode } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import { useLayoutEffect, useRef, type ReactNode } from "react";
+import { usePathname } from "next/navigation";
 
-/** Fade the current page before navigation, then reveal the committed route. */
+/** Reveal committed pages without delaying navigation or freezing the old screen. */
 export function PageTransition({ children }: { children: ReactNode }) {
   const pathname = usePathname();
-  const router = useRouter();
   const main = useRef<HTMLElement>(null);
-  const animation = useRef<Animation | null>(null);
-  const transition = useRef<ViewTransition | null>(null);
-  const finishRoute = useRef<(() => void) | null>(null);
   const previousPath = useRef(pathname);
-  const request = useRef(0);
-  const timeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useLayoutEffect(() => {
     if (previousPath.current === pathname) return;
     previousPath.current = pathname;
-    request.current++;
-    if (timeout.current) clearTimeout(timeout.current);
-    animation.current?.cancel();
-    if (finishRoute.current) {
-      finishRoute.current();
-      finishRoute.current = null;
-      return;
-    }
-    if (!window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
-      const enter = main.current?.animate([{ opacity: 0 }, { opacity: 1 }], {
-        duration: 230,
-        easing: "cubic-bezier(0.22, 1, 0.36, 1)",
-      });
-      animation.current = enter ?? null;
-    }
-  }, [pathname]);
-
-  useEffect(() => {
-    const container = main.current;
-    // Navigation links also live in the persistent sidebar and mobile header.
-    const navigate = async (event: globalThis.MouseEvent) => {
-      if (
-        event.defaultPrevented ||
-        event.button !== 0 ||
-        event.metaKey ||
-        event.ctrlKey ||
-        event.shiftKey ||
-        event.altKey
-      )
-        return;
-      const link = (event.target as Element).closest<HTMLAnchorElement>("a[href]");
-      if (!link || (link.target && link.target !== "_self") || link.hasAttribute("download"))
-        return;
-      const url = new URL(link.href, window.location.href);
-      if (
-        url.origin !== window.location.origin ||
-        url.pathname === window.location.pathname ||
-        url.pathname.startsWith("/api/")
-      )
-        return;
-      if (window.matchMedia("(prefers-reduced-motion: reduce)").matches || !container) return;
-      event.preventDefault();
-      const token = ++request.current;
-      if (timeout.current) clearTimeout(timeout.current);
-      transition.current?.skipTransition();
-      finishRoute.current?.();
-      finishRoute.current = null;
-      if (typeof document.startViewTransition === "function") {
-        // Hold the old frame until the next route has committed. Slow routes
-        // never leave a blank page between the fade-out and fade-in.
-        animation.current?.cancel();
-        const next = document.startViewTransition(
-          () =>
-            new Promise<void>((resolve) => {
-              if (request.current !== token) {
-                resolve();
-                return;
-              }
-              finishRoute.current = resolve;
-              router.push(`${url.pathname}${url.search}${url.hash}`);
-              timeout.current = setTimeout(() => {
-                if (request.current !== token) return;
-                next.skipTransition();
-                finishRoute.current = null;
-                resolve();
-              }, 2500);
-            }),
-        );
-        transition.current = next;
-        void next.ready.catch(() => {});
-        void next.finished
-          .catch(() => {})
-          .then(() => {
-            if (transition.current === next) transition.current = null;
-          });
-        return;
-      }
-      const opacity = getComputedStyle(container).opacity;
-      animation.current?.cancel();
-      const exit = container.animate([{ opacity }, { opacity: 0 }], {
-        duration: 120,
-        easing: "ease-out",
-        fill: "forwards",
-      });
-      animation.current = exit;
-      try {
-        await exit.finished;
-      } catch {
-        return;
-      }
-      if (request.current !== token) return;
-      router.push(`${url.pathname}${url.search}${url.hash}`);
-      // A failed or cancelled navigation must never leave the page invisible.
-      timeout.current = setTimeout(() => {
-        if (request.current === token) animation.current?.cancel();
-      }, 2000);
+    const motion = window.matchMedia("(prefers-reduced-motion: reduce)");
+    if (motion.matches) return;
+    const animation = main.current?.animate([{ opacity: 0.65 }, { opacity: 1 }], {
+      duration: 160,
+      easing: "ease-out",
+    });
+    const settle = () => {
+      if (motion.matches) animation?.cancel();
     };
-    document.addEventListener("click", navigate, true);
+    motion.addEventListener("change", settle);
     return () => {
-      document.removeEventListener("click", navigate, true);
-      request.current++;
-      animation.current?.cancel();
-      transition.current?.skipTransition();
-      finishRoute.current?.();
-      finishRoute.current = null;
-      if (timeout.current) clearTimeout(timeout.current);
+      animation?.cancel();
+      motion.removeEventListener("change", settle);
     };
-  }, [router]);
+  }, [pathname]);
 
   return (
     <main ref={main} className="journal-main min-w-0 flex-1" data-page-transition>

--- a/apps/web/src/components/performance-trends.tsx
+++ b/apps/web/src/components/performance-trends.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { MIN_TREND_POINTS, type PerformanceTrendsResponse } from "@/lib/performance-trends";
+import { useApi } from "@/lib/use-api";
+import { fmtPercent } from "@/lib/utils";
+import { Pnl } from "./pnl";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { Button } from "./ui/button";
+import { Skeleton } from "./ui/skeleton";
+
+const RollingTradeChart = dynamic(
+  () => import("./charts/rolling-trade-chart").then((module) => module.RollingTradeChart),
+  {
+    loading: () => (
+      <div role="status" aria-label="Loading trend chart">
+        <Skeleton className="h-60" />
+      </div>
+    ),
+  },
+);
+const tradeHref = (key: string) => `/trades/${encodeURIComponent(key)}`;
+
+export function PerformanceTrendsReport({ query }: { query: string }) {
+  const { data, loading, error, refresh } = useApi<PerformanceTrendsResponse>(
+    `/api/performance-trends?${query}`,
+  );
+  const [tableOpen, setTableOpen] = useState(false);
+  const dateFormat = useMemo(
+    () =>
+      new Intl.DateTimeFormat("en", {
+        timeZone: data?.timeZone ?? "UTC",
+        dateStyle: "medium",
+        timeStyle: "short",
+      }),
+    [data?.timeZone],
+  );
+  if (loading)
+    return (
+      <div
+        role="status"
+        aria-label="Loading performance trends"
+        className="grid gap-3 md:grid-cols-2"
+      >
+        <Skeleton className="h-80" />
+        <Skeleton className="h-80" />
+      </div>
+    );
+  if (error || !data)
+    return (
+      <div role="alert" className="rounded-xl border p-5">
+        <p className="text-sm text-destructive">{error ?? "Unable to load performance trends."}</p>
+        <Button onClick={refresh} variant="outline" size="sm" className="mt-3">
+          Try again
+        </Button>
+      </div>
+    );
+  const { trends, timeZone, currencies } = data;
+  const currency = currencies[0] ?? "USD";
+  const monetary = currencies.length <= 1;
+  const latest = trends.points.at(-1);
+  const chartReady = trends.points.length >= MIN_TREND_POINTS;
+  return (
+    <section
+      className="space-y-4"
+      aria-labelledby="performance-trends-title"
+      data-performance-trends
+    >
+      <div>
+        <h2 id="performance-trends-title" className="text-lg font-semibold">
+          Performance trends
+        </h2>
+        <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+          {trends.count} closed trades · Active account and filters · Closing order · {timeZone}
+          {monetary && trends.count > 0 ? ` · ${currency}` : ""}
+        </p>
+      </div>
+      {trends.count === 0 ? (
+        <Card>
+          <CardContent className="py-10 text-center">
+            <h3 className="font-medium">No closed trades in this selection</h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Change the date range or filters to explore your trading history. Open positions are
+              excluded.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          {!monetary && (
+            <p
+              role="note"
+              className="rounded-xl border bg-muted/30 p-4 text-sm text-muted-foreground"
+            >
+              These trades use different currencies ({currencies.join(", ")}). Win rate is
+              available; select accounts with one currency to compare P&L and largest trades. No
+              currency conversion is applied.
+            </p>
+          )}
+          <div className={`grid items-start gap-3 ${monetary ? "lg:grid-cols-2" : ""}`}>
+            {(["winRate", ...(monetary ? ["avgNetPnl" as const] : [])] as const).map((metric) => {
+              const rate = metric === "winRate";
+              const reference = rate ? trends.overallWinRate! : trends.overallAvgNetPnl!;
+              return (
+                <Card key={metric} className="min-w-0 overflow-hidden">
+                  <CardHeader>
+                    <CardTitle>{rate ? "Win-rate trend" : "Average trade P&L trend"}</CardTitle>
+                    <p className="text-xs text-muted-foreground">
+                      Last 20 closed trades at each point
+                      {rate ? " · Breakevens included" : " · After fees"}
+                    </p>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="flex flex-wrap items-end justify-between gap-3">
+                      <div>
+                        <p className="text-xs text-muted-foreground">Latest full window</p>
+                        <p className="mt-1 text-2xl font-semibold tabular-nums">
+                          {latest ? (
+                            rate ? (
+                              fmtPercent(latest.winRate, 1)
+                            ) : (
+                              <Pnl value={latest.avgNetPnl} currency={currency} />
+                            )
+                          ) : (
+                            "—"
+                          )}
+                        </p>
+                      </div>
+                      <div className="text-right text-xs text-muted-foreground">
+                        <p>Selected-period {rate ? "win rate" : "average"}</p>
+                        <p className="mt-1 text-sm tabular-nums">
+                          {rate ? (
+                            fmtPercent(reference, 1)
+                          ) : (
+                            <Pnl value={reference} currency={currency} />
+                          )}
+                        </p>
+                      </div>
+                    </div>
+                    {chartReady ? (
+                      <>
+                        <RollingTradeChart
+                          data={trends.points}
+                          metric={metric}
+                          reference={reference}
+                          currency={currency}
+                          timeZone={timeZone}
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          Closed-trade sequence · Dashed line: selected-period{" "}
+                          {rate ? "win rate" : "average"}
+                        </p>
+                      </>
+                    ) : (
+                      <div className="rounded-lg bg-muted/30 px-4 py-6 text-sm leading-relaxed text-muted-foreground">
+                        {!latest
+                          ? `${20 - trends.count} more closed ${20 - trends.count === 1 ? "trade is" : "trades are"} needed for the first full 20-trade window.`
+                          : `Latest window available. A line chart appears at 27 closed trades, when there are 8 full windows to compare.`}
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+          {monetary && (
+            <Card className="min-w-0">
+              <CardHeader>
+                <CardTitle>Largest winning and losing trade</CardTitle>
+                <p className="text-xs text-muted-foreground">
+                  Individual closed trades, after fees—not daily totals. Uses your journal’s
+                  win/loss classification.
+                </p>
+              </CardHeader>
+              <CardContent className="grid gap-4 sm:grid-cols-2">
+                {(
+                  [
+                    ["Largest winner", trends.largestWin],
+                    ["Largest loser", trends.largestLoss],
+                  ] as const
+                ).map(([label, trade]) => (
+                  <div key={label} className="min-w-0 rounded-lg border p-4">
+                    <h3 className="text-xs text-muted-foreground">{label}</h3>
+                    {trade ? (
+                      <>
+                        <p className="mt-2 text-xl font-semibold">
+                          <Pnl value={trade.netPnl} currency={currency} />
+                        </p>
+                        <Link
+                          href={tradeHref(trade.key)}
+                          className="mt-2 inline-flex max-w-full flex-wrap items-center gap-x-2 gap-y-1 rounded text-sm underline decoration-muted-foreground/40 underline-offset-4 hover:decoration-current"
+                        >
+                          <span className="break-all font-medium">
+                            {trade.symbol} · {trade.direction}
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            {dateFormat.format(new Date(trade.closedAt))} ↗
+                          </span>
+                        </Link>
+                      </>
+                    ) : (
+                      <p className="mt-3 text-sm text-muted-foreground">
+                        No {label === "Largest winner" ? "winning" : "losing"} trades in this
+                        selection.
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          )}
+          {latest && (
+            <details
+              className="rounded-xl border bg-card"
+              onToggle={(event) => setTableOpen(event.currentTarget.open)}
+            >
+              <summary className="cursor-pointer rounded-xl px-4 py-3 text-sm font-medium">
+                Explore window values and trades
+              </summary>
+              {tableOpen && (
+                <div className="max-h-72 overflow-auto px-4 pb-4">
+                  <table className="w-full text-left text-xs">
+                    <caption className="pb-3 text-left text-muted-foreground">
+                      Each row covers 20 trades ending at the linked trade. Dates use {timeZone}.
+                    </caption>
+                    <thead>
+                      <tr className="border-b">
+                        <th scope="col" className="py-2 pr-3">
+                          Window / closing trade
+                        </th>
+                        <th scope="col" className="px-2 text-right">
+                          Win rate
+                        </th>
+                        {monetary && (
+                          <th scope="col" className="pl-2 text-right">
+                            Avg net P&L
+                          </th>
+                        )}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {trends.points.map((point) => (
+                        <tr key={point.key} className="border-b last:border-0">
+                          <th scope="row" className="py-3 pr-3 font-normal">
+                            <Link
+                              className="rounded underline underline-offset-4"
+                              href={tradeHref(point.key)}
+                            >
+                              #{point.sequence - 19}–{point.sequence}
+                              <span className="mt-1 block text-muted-foreground">
+                                {dateFormat.format(new Date(point.closedAt))}
+                              </span>
+                            </Link>
+                          </th>
+                          <td className="px-2 text-right tabular-nums">
+                            {fmtPercent(point.winRate, 1)}
+                          </td>
+                          {monetary && (
+                            <td className="pl-2 text-right">
+                              <Pnl value={point.avgNetPnl} currency={currency} />
+                            </td>
+                          )}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </details>
+          )}
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Only trades within your selection are used; earlier trades are not borrowed to fill a
+            window. Rolling windows overlap and describe recent results—not a forecast. Small
+            samples can change sharply.
+          </p>
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/pnl.tsx
+++ b/apps/web/src/components/pnl.tsx
@@ -2,10 +2,18 @@ import { cn, fmtMoney, pnlClass } from "@/lib/utils";
 import { MonetaryValue } from "./privacy";
 
 /** Signed P&L text — the sign carries polarity; color only reinforces it. */
-export function Pnl({ value, className }: { value: number; className?: string }) {
+export function Pnl({
+  value,
+  className,
+  currency = "USD",
+}: {
+  value: number;
+  className?: string;
+  currency?: string;
+}) {
   return (
     <span className={cn("tnum", pnlClass(value), className)}>
-      <MonetaryValue>{fmtMoney(value)}</MonetaryValue>
+      <MonetaryValue>{fmtMoney(value, currency)}</MonetaryValue>
     </span>
   );
 }

--- a/apps/web/src/components/privacy.tsx
+++ b/apps/web/src/components/privacy.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
 import { Eye, EyeOff } from "lucide-react";
 import { Button } from "./ui/button";
+import { HoverHint } from "./ui/tooltip";
 import { PRIVACY_KEY, LEGACY_LAYOUT_KEY, privacyPreference } from "@/lib/privacy-preference";
 
 const PrivacyContext = createContext({ enabled: true, ready: false, error: "", toggle: () => {} });
@@ -51,22 +52,35 @@ export function PrivacyProvider({ children }: { children: ReactNode }) {
   );
 }
 
-export function PrivacyToggle({ compact = false }: { compact?: boolean }) {
+export function PrivacyToggle({
+  compact = false,
+  iconOnly = false,
+}: {
+  compact?: boolean;
+  iconOnly?: boolean;
+}) {
   const { enabled, ready, error, toggle } = useContext(PrivacyContext);
   return (
     <div className={compact ? "relative shrink-0" : "space-y-2"}>
       <Button
-        className={compact ? "h-9 gap-1.5 rounded-xl px-2.5 text-xs" : "w-full justify-start gap-2"}
+        className={
+          iconOnly
+            ? "h-9 w-9 rounded-lg p-0"
+            : compact
+              ? "h-9 gap-1.5 rounded-xl px-2.5 text-xs"
+              : "w-full justify-start gap-2"
+        }
         size="sm"
         variant={enabled ? "secondary" : "outline"}
-        aria-label="Privacy mode"
+        aria-label={`Privacy mode ${enabled ? "on" : "off"}`}
         aria-pressed={enabled}
         disabled={!ready}
         onClick={toggle}
         title="Hide balances, P&L and trade prices across the journal"
       >
-        {enabled ? <EyeOff /> : <Eye />} {compact ? "Privacy" : "Privacy mode"}
-        <span className="ml-auto text-xs">{enabled ? "On" : "Off"}</span>
+        {enabled ? <EyeOff /> : <Eye />}
+        {!iconOnly && (compact ? "Privacy" : "Privacy mode")}
+        {!iconOnly && <span className="ml-auto text-xs">{enabled ? "On" : "Off"}</span>}
       </Button>
       {error && (
         <p
@@ -97,13 +111,15 @@ export function MonetaryField({
 }) {
   const enabled = usePrivacy();
   return enabled && sensitive ? (
-    <div
-      className="flex h-9 items-center rounded-md border px-3 text-sm"
-      aria-label="Monetary value hidden"
-      title="Turn off privacy mode to edit this value"
-    >
-      ••••
-    </div>
+    <HoverHint content="Turn off privacy mode to edit this value">
+      <div
+        className="flex h-9 items-center rounded-md border px-3 text-sm"
+        aria-label="Monetary value hidden"
+        tabIndex={0}
+      >
+        ••••
+      </div>
+    </HoverHint>
   ) : (
     children
   );

--- a/apps/web/src/components/rich-editor.tsx
+++ b/apps/web/src/components/rich-editor.tsx
@@ -4,6 +4,13 @@ import Link from "next/link";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Button } from "@/components/ui/button";
+import { ChevronDown, FileText } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
 import { fieldClass } from "@/components/filter-fields";
 import { postJson, useApi } from "@/lib/use-api";
 import { formatInlineSelection, remarkRepairSpacedEmphasis } from "@/lib/note-formatting";
@@ -189,24 +196,34 @@ export function RichEditor({
             <Button type="button" size="sm" variant="ghost" onClick={() => setLinkOpen(!linkOpen)}>
               Link trade
             </Button>
-            <select
-              aria-label="Insert note template"
-              className={`${fieldClass} !w-auto max-w-44`}
-              value=""
-              onChange={(e) => {
-                const template = [...BUILT_INS, ...(data?.templates ?? [])].find(
-                  (t) => t.id === e.target.value,
-                );
-                if (template) onChange(value + (value ? "\n\n" : "") + template.content);
-              }}
-            >
-              <option value="">Insert template…</option>
-              {[...BUILT_INS, ...(data?.templates ?? [])].map((t) => (
-                <option key={t.id} value={t.id}>
-                  {t.name}
-                </option>
-              ))}
-            </select>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  aria-label="Insert note template"
+                  className="gap-2 rounded-lg"
+                >
+                  Insert template…
+                  <ChevronDown className="size-3.5 text-muted-foreground" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" aria-label="Note templates">
+                {[...BUILT_INS, ...(data?.templates ?? [])].map((template) => (
+                  <DropdownMenuItem
+                    key={template.id}
+                    onSelect={() => onChange(value + (value ? "\n\n" : "") + template.content)}
+                  >
+                    <FileText
+                      aria-hidden="true"
+                      className="size-3.5 shrink-0 text-muted-foreground"
+                    />
+                    {template.name}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
             <Button
               type="button"
               size="sm"

--- a/apps/web/src/components/rule-checklist.tsx
+++ b/apps/web/src/components/rule-checklist.tsx
@@ -1,4 +1,6 @@
 "use client";
+import { OptionSelect } from "@/components/ui/option-select";
+
 import { useState } from "react";
 import { useApi, postJson } from "@/lib/use-api";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
@@ -44,16 +46,15 @@ export function RuleChecklist({
                 className="flex items-center justify-between gap-3 border-t pt-2 text-sm"
               >
                 <span>{r.rule}</span>
-                <select
+                <OptionSelect
                   aria-label={r.rule}
                   className={`${fieldClass} !w-32 shrink-0`}
                   value={r.followed === null ? "unreviewed" : String(r.followed)}
-                  onChange={async (e) => {
+                  onValueChange={async (next) => {
                     try {
                       await postJson(url, {
                         rule: r.rule,
-                        followed:
-                          e.target.value === "unreviewed" ? null : e.target.value === "true",
+                        followed: next === "unreviewed" ? null : next === "true",
                       });
                       refresh();
                       setFailure("");
@@ -65,7 +66,7 @@ export function RuleChecklist({
                   <option value="unreviewed">Not assessed</option>
                   <option value="true">Followed</option>
                   <option value="false">Broken</option>
-                </select>
+                </OptionSelect>
               </label>
             ))}
           </>

--- a/apps/web/src/components/shell.tsx
+++ b/apps/web/src/components/shell.tsx
@@ -19,13 +19,17 @@ import {
   BookmarkPlus,
   Wallet,
   Menu,
+  PanelLeftClose,
+  PanelLeftOpen,
   X,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { LuxAlgoMark } from "@/components/luxalgo-mark";
 import { PrivacyToggle } from "./privacy";
+import { ThemeToggle } from "./theme";
 import { PageTransition } from "./page-transition";
 import { Button } from "./ui/button";
+import { HoverHint } from "./ui/tooltip";
 
 const NAV = [
   { href: "/", label: "Dashboard", icon: LayoutDashboard },
@@ -45,32 +49,37 @@ const NAV_SETUP = [
   { href: "/settings", label: "Settings", icon: Settings },
 ] as const;
 
+const SIDEBAR_COLLAPSED_KEY = "journal-sidebar-collapsed-v1";
+
 function NavLink({
   href,
   label,
   icon: Icon,
   active,
+  collapsed = false,
 }: {
   href: string;
   label: string;
   icon: React.ComponentType<{ className?: string }>;
   active: boolean;
+  collapsed?: boolean;
 }) {
   return (
-    <Link
-      href={href}
-      aria-current={active ? "page" : undefined}
-      className={cn(
-        "relative flex items-center gap-2.5 rounded-md px-2.5 py-2 text-sm transition-colors",
-        active
-          ? "bg-accent font-medium text-accent-foreground"
-          : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
-      )}
-    >
-      {active && <span className="prism-bar absolute left-0 h-4 w-0.5 rounded-full" />}
-      <Icon className={cn("h-4 w-4", active && "text-brand")} />
-      {label}
-    </Link>
+    <HoverHint content={collapsed ? label : null} side="right">
+      <Link
+        href={href}
+        aria-current={active ? "page" : undefined}
+        className={cn(
+          "journal-sidebar-nav-link relative flex items-center gap-2.5 rounded-md px-2.5 py-2 text-sm transition-colors",
+          active
+            ? "bg-accent font-medium text-accent-foreground"
+            : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+        )}
+      >
+        <Icon className={cn("h-4 w-4", active && "text-brand")} />
+        <span className="journal-sidebar-label">{label}</span>
+      </Link>
+    </HoverHint>
   );
 }
 
@@ -78,6 +87,8 @@ export function Shell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const search = useSearchParams();
   const [menuOpen, setMenuOpen] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarReady, setSidebarReady] = useState(false);
   useEffect(() => setMenuOpen(false), [pathname]);
   useEffect(() => {
     const desktop = window.matchMedia("(min-width: 1024px)");
@@ -87,6 +98,45 @@ export function Shell({ children }: { children: React.ReactNode }) {
     desktop.addEventListener("change", closeOnDesktop);
     return () => desktop.removeEventListener("change", closeOnDesktop);
   }, []);
+  useEffect(() => {
+    const read = () => {
+      try {
+        setSidebarCollapsed(localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "true");
+      } catch {
+        setSidebarCollapsed(false);
+      } finally {
+        setSidebarReady(true);
+      }
+    };
+    read();
+    const sync = (event: StorageEvent) => {
+      if (event.key === SIDEBAR_COLLAPSED_KEY || event.key === null) read();
+    };
+    window.addEventListener("storage", sync);
+    return () => window.removeEventListener("storage", sync);
+  }, []);
+  useEffect(() => {
+    const shortcut = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== "b") return;
+      const target = event.target as HTMLElement | null;
+      if (target?.closest("input, textarea, select, [contenteditable='true']")) return;
+      event.preventDefault();
+      toggleSidebar();
+    };
+    window.addEventListener("keydown", shortcut);
+    return () => window.removeEventListener("keydown", shortcut);
+  }, []);
+  function toggleSidebar() {
+    setSidebarCollapsed((collapsed) => {
+      const next = !collapsed;
+      try {
+        localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(next));
+      } catch {
+        // The interaction still works when storage is unavailable.
+      }
+      return next;
+    });
+  }
   const filterQuery = new URLSearchParams();
   for (const key of FILTER_KEYS) {
     const value = search.get(key);
@@ -94,10 +144,10 @@ export function Shell({ children }: { children: React.ReactNode }) {
   }
   if (search.get("range")) filterQuery.set("range", search.get("range")!);
   if (pathname === "/login") return <>{children}</>;
-  const navigation = (
+  const navigation = (collapsed = false) => (
     <nav
       aria-label="Journal navigation"
-      className="min-h-0 flex-1 space-y-0.5 overflow-y-auto overscroll-contain p-2"
+      className="journal-sidebar-navigation min-h-0 flex-1 space-y-0.5 overflow-x-hidden overflow-y-auto overscroll-contain p-2"
       onClick={(event) => {
         if ((event.target as HTMLElement).closest("a")) setMenuOpen(false);
       }}
@@ -108,6 +158,7 @@ export function Shell({ children }: { children: React.ReactNode }) {
           href={filterQuery.size ? `${href}?${filterQuery}` : href}
           label={label}
           icon={icon}
+          collapsed={collapsed}
           active={href === "/" ? pathname === "/" : pathname.startsWith(href)}
         />
       ))}
@@ -118,13 +169,14 @@ export function Shell({ children }: { children: React.ReactNode }) {
           href={filterQuery.size ? `${href}?${filterQuery}` : href}
           label={label}
           icon={icon}
+          collapsed={collapsed}
           active={pathname.startsWith(href)}
         />
       ))}
     </nav>
   );
   const footer = (
-    <div className="space-y-1 border-t p-3 text-xs text-muted-foreground">
+    <div className="journal-sidebar-footer space-y-1 border-t p-3 text-xs text-muted-foreground">
       <div>
         Open source ·{" "}
         <a
@@ -175,7 +227,7 @@ export function Shell({ children }: { children: React.ReactNode }) {
                   </Button>
                 </DialogPrimitive.Close>
               </div>
-              {navigation}
+              {navigation()}
               <div className="border-t p-3">
                 <PrivacyToggle />
               </div>
@@ -191,15 +243,44 @@ export function Shell({ children }: { children: React.ReactNode }) {
           <span className="truncate">Trade Journal</span>
         </Link>
         <PrivacyToggle compact />
+        <ThemeToggle iconOnly />
       </header>
-      <aside className="journal-desktop-sidebar sticky top-0 hidden h-dvh w-52 shrink-0 flex-col border-r bg-card/50 lg:flex">
-        <Link href="/" className="flex h-14 shrink-0 items-center gap-2.5 border-b px-4">
-          <LuxAlgoMark className="h-[18px] w-5 shrink-0" />
-          <span className="text-sm font-semibold tracking-tight">Trade Journal</span>
-        </Link>
-        {navigation}
-        <div className="border-t p-3">
-          <PrivacyToggle />
+      <aside
+        className="journal-desktop-sidebar sticky top-0 hidden h-dvh shrink-0 flex-col border-r bg-card/50 lg:flex"
+        data-collapsed={sidebarCollapsed}
+        data-ready={sidebarReady}
+      >
+        <div className="journal-sidebar-header relative flex h-14 shrink-0 items-center border-b">
+          <Link href="/" className="journal-sidebar-home flex h-full min-w-0 items-center gap-2.5">
+            <LuxAlgoMark className="h-[18px] w-5 shrink-0" />
+            <span className="journal-sidebar-brand-label text-sm font-semibold tracking-tight">
+              Trade Journal
+            </span>
+          </Link>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="journal-sidebar-trigger absolute h-7 w-7 rounded-full bg-background shadow-sm"
+            onClick={toggleSidebar}
+            aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+            aria-expanded={!sidebarCollapsed}
+            aria-keyshortcuts="Meta+B Control+B"
+            title={`${sidebarCollapsed ? "Expand" : "Collapse"} sidebar (⌘B)`}
+          >
+            {sidebarCollapsed ? (
+              <PanelLeftOpen className="h-3.5 w-3.5" />
+            ) : (
+              <PanelLeftClose className="h-3.5 w-3.5" />
+            )}
+          </Button>
+        </div>
+        {navigation(sidebarCollapsed)}
+        <div className="journal-sidebar-privacy border-t p-3">
+          <div className="w-full space-y-1">
+            <ThemeToggle iconOnly={sidebarCollapsed} />
+            <PrivacyToggle iconOnly={sidebarCollapsed} />
+          </div>
         </div>
         {footer}
       </aside>

--- a/apps/web/src/components/theme.tsx
+++ b/apps/web/src/components/theme.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import { Moon, Sun } from "lucide-react";
+import { THEME_KEY, themePreference, type Theme } from "@/lib/theme";
+import { Button } from "./ui/button";
+
+const ThemeContext = createContext({ theme: "dark" as Theme, ready: false, toggle: () => {} });
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>("dark");
+  const [ready, setReady] = useState(false);
+  const [error, setError] = useState("");
+  const apply = (next: Theme) => {
+    document.documentElement.classList.toggle("dark", next === "dark");
+    setTheme(next);
+  };
+  useEffect(() => {
+    // Read the pre-paint result, including its storage-unavailable fallback.
+    setTheme(document.documentElement.classList.contains("dark") ? "dark" : "light");
+    setReady(true);
+    const sync = (event: StorageEvent) => {
+      if (event.key === THEME_KEY || event.key === null) {
+        apply(themePreference(event.newValue));
+        setError("");
+      }
+    };
+    window.addEventListener("storage", sync);
+    return () => window.removeEventListener("storage", sync);
+  }, []);
+  const toggle = () => {
+    const next = theme === "dark" ? "light" : "dark";
+    apply(next);
+    try {
+      localStorage.setItem(THEME_KEY, next);
+      setError("");
+    } catch {
+      setError("Appearance changed, but your browser could not save it for next time.");
+    }
+  };
+  return (
+    <ThemeContext.Provider value={{ theme, ready, toggle }}>
+      {children}
+      {error && (
+        <p
+          role="status"
+          className="fixed bottom-4 right-4 z-50 max-w-[calc(100vw-32px)] rounded-lg border bg-popover px-4 py-3 text-sm text-popover-foreground shadow-lg"
+        >
+          {error}
+        </p>
+      )}
+    </ThemeContext.Provider>
+  );
+}
+
+export function ThemeToggle({ iconOnly = false }: { iconOnly?: boolean }) {
+  const { theme, ready, toggle } = useContext(ThemeContext);
+  const label = theme === "dark" ? "Switch to light mode" : "Switch to dark mode";
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size={iconOnly ? "icon" : "sm"}
+      className={
+        iconOnly
+          ? "h-9 w-9 shrink-0 rounded-lg"
+          : "w-full justify-start gap-2 text-muted-foreground hover:text-foreground"
+      }
+      disabled={!ready}
+      onClick={toggle}
+      aria-label={label}
+      title={iconOnly ? label : undefined}
+    >
+      {theme === "dark" ? <Sun aria-hidden="true" /> : <Moon aria-hidden="true" />}
+      {!iconOnly && (theme === "dark" ? "Light mode" : "Dark mode")}
+    </Button>
+  );
+}

--- a/apps/web/src/components/trade-chart.tsx
+++ b/apps/web/src/components/trade-chart.tsx
@@ -105,7 +105,7 @@ function PriceChart({
       const { Vela, registerNativeIndicator, unregisterNativeIndicator } = vela;
       if (disposed || !hostRef.current) return;
 
-      const dark = document.documentElement.classList.contains("dark");
+      let dark = document.documentElement.classList.contains("dark");
       const sorted = [...executions].sort(
         (a, b) => Date.parse(a.executedAt) - Date.parse(b.executedAt),
       );
@@ -117,9 +117,9 @@ function PriceChart({
       const pad = Math.max(durationMs * 0.35, 15 * 60_000);
       const crypto = looksCrypto(trade);
 
-      const profitColor = "#0ca30c";
+      let profitColor = dark ? "#0ca30c" : "#006300";
       const lossColor = "#d03b3b";
-      const entryColor = trade.direction === "long" ? profitColor : lossColor;
+      let entryColor = trade.direction === "long" ? profitColor : lossColor;
 
       // Engine-free trade painting: a per-mount native indicator that emits
       // arrow labels for each fill plus an entry→exit line with the P&L.
@@ -236,8 +236,24 @@ function PriceChart({
         });
 
       let chart = buildChart(!crypto);
-      chart.addNativeIndicator(type);
+      let indicator = chart.addNativeIndicator(type);
+      const themeObserver = new MutationObserver(() => {
+        const nextDark = document.documentElement.classList.contains("dark");
+        if (dark === nextDark) return;
+        dark = nextDark;
+        profitColor = dark ? "#0ca30c" : "#006300";
+        entryColor = trade.direction === "long" ? profitColor : lossColor;
+        chart.setTheme(dark ? "dark" : "light");
+        // Repaint annotations without recreating the price chart or fetching candles.
+        indicator.remove();
+        indicator = chart.addNativeIndicator(type);
+      });
+      themeObserver.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["class"],
+      });
       cleanup = () => {
+        themeObserver.disconnect();
         chart.destroy();
         unregisterNativeIndicator(type);
       };
@@ -266,7 +282,7 @@ function PriceChart({
           if (disposed) return;
           chart.destroy();
           chart = buildChart(true);
-          chart.addNativeIndicator(type);
+          indicator = chart.addNativeIndicator(type);
         }
       }
     })();

--- a/apps/web/src/components/trade-explorer.tsx
+++ b/apps/web/src/components/trade-explorer.tsx
@@ -154,11 +154,7 @@ export function TradeExplorer({ query }: { query: string }) {
     </div>
   );
   return (
-    <section
-      className="space-y-4"
-      aria-labelledby="trade-explorer-title"
-      data-trade-explorer
-    >
+    <section className="space-y-4" aria-labelledby="trade-explorer-title" data-trade-explorer>
       <div>
         <h2 id="trade-explorer-title" className="text-lg font-semibold">
           Trade explorer

--- a/apps/web/src/components/trade-explorer.tsx
+++ b/apps/web/src/components/trade-explorer.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import {
+  clockLabel,
+  plotTradePoints,
+  type PlottedTrade,
+  type TradeExplorerResponse,
+  type TradeXAxis,
+  type TradeYAxis,
+} from "@/lib/trade-explorer";
+import { useApi } from "@/lib/use-api";
+import { Pnl } from "./pnl";
+import { Button } from "./ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { OptionSelect } from "./ui/option-select";
+import { Skeleton } from "./ui/skeleton";
+
+const TradeScatter = dynamic(
+  () => import("./charts/trade-scatter").then((module) => module.TradeScatter),
+  {
+    loading: () => (
+      <div role="status" aria-label="Loading scatter plot">
+        <Skeleton className="h-80" />
+      </div>
+    ),
+  },
+);
+const PAGE_SIZE = 25;
+const detailHref = (key: string) => `/trades/${encodeURIComponent(key)}`;
+
+export function TradeExplorer({ query }: { query: string }) {
+  const { data, error, loading, refresh } = useApi<TradeExplorerResponse>(
+    `/api/trade-explorer?${query}`,
+  );
+  const [x, setX] = useState<TradeXAxis>("durationMinutes");
+  const [y, setY] = useState<TradeYAxis>("netPnl");
+  const [selected, setSelected] = useState<PlottedTrade | null>(null);
+  const [page, setPage] = useState(0);
+  const [tableOpen, setTableOpen] = useState(false);
+  const points = useMemo(() => plotTradePoints(data?.points ?? [], x, y), [data, x, y]);
+  const date = useMemo(
+    () =>
+      new Intl.DateTimeFormat("en", {
+        timeZone: data?.timeZone ?? "UTC",
+        dateStyle: "medium",
+        timeStyle: "short",
+      }),
+    [data?.timeZone],
+  );
+  if (loading)
+    return (
+      <div role="status" aria-label="Loading trade explorer">
+        <Skeleton className="h-96" />
+      </div>
+    );
+  if (error || !data)
+    return (
+      <div role="alert" className="rounded-xl border p-5">
+        <p className="text-sm text-destructive">{error ?? "Unable to load trade explorer."}</p>
+        <Button onClick={refresh} variant="outline" size="sm" className="mt-3">
+          Try again
+        </Button>
+      </div>
+    );
+  const currency = data.currencies[0] ?? "USD";
+  const blocked = y === "netPnl" && data.currencies.length > 1;
+  const xTitle = x === "durationMinutes" ? "Duration (minutes)" : `Entry time (${data.timeZone})`;
+  const yTitle = y === "netPnl" ? `Net P&L (${currency})` : "Realized R";
+  const value = (point: PlottedTrade) =>
+    y === "netPnl" ? (
+      <Pnl value={point.y} currency={currency} />
+    ) : (
+      <span className="tabular-nums">
+        {point.y > 0 ? "+" : ""}
+        {point.y.toFixed(2)}R
+      </span>
+    );
+  const xValue = (point: PlottedTrade) =>
+    x === "entryMinute"
+      ? clockLabel(point.x)
+      : `${point.x.toLocaleString(undefined, { maximumFractionDigits: 2 })} min`;
+  const pages = Math.ceil(points.length / PAGE_SIZE);
+  const shownPage = Math.min(page, Math.max(0, pages - 1));
+  const table = (
+    <div className="space-y-3 px-4 pb-4">
+      <div className="overflow-x-auto">
+        <table className="w-full text-left text-xs">
+          <caption className="pb-3 text-left text-muted-foreground">
+            All {points.length} comparable trades, newest close first. Each link opens the original
+            trade.
+          </caption>
+          <thead>
+            <tr className="border-b">
+              <th scope="col" className="py-2 pr-3">
+                Trade / closed
+              </th>
+              <th scope="col" className="px-2 text-right">
+                {xTitle}
+              </th>
+              <th scope="col" className="pl-2 text-right">
+                {yTitle}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {points.slice(shownPage * PAGE_SIZE, (shownPage + 1) * PAGE_SIZE).map((point) => (
+              <tr key={point.key} className="border-b last:border-0">
+                <th scope="row" className="py-3 pr-3 font-normal">
+                  <Link
+                    href={detailHref(point.key)}
+                    className="rounded underline underline-offset-4"
+                  >
+                    <span className="break-all font-medium">
+                      {point.symbol} · {point.direction}
+                    </span>
+                    <span className="mt-1 block text-muted-foreground">
+                      {date.format(new Date(point.closedAt))}
+                    </span>
+                  </Link>
+                </th>
+                <td className="px-2 text-right tabular-nums">{xValue(point)}</td>
+                <td className="pl-2 text-right">{value(point)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {pages > 1 && (
+        <div className="flex items-center justify-between gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={shownPage === 0}
+            onClick={() => setPage(shownPage - 1)}
+          >
+            Previous
+          </Button>
+          <p aria-live="polite" className="text-xs text-muted-foreground">
+            Page {shownPage + 1} of {pages}
+          </p>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={shownPage === pages - 1}
+            onClick={() => setPage(shownPage + 1)}
+          >
+            Next
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+  return (
+    <section
+      className="space-y-4"
+      aria-labelledby="trade-explorer-title"
+      data-trade-explorer
+    >
+      <div>
+        <h2 id="trade-explorer-title" className="text-lg font-semibold">
+          Trade explorer
+        </h2>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Compare individual trades, not group averages · Active account and filters ·{" "}
+          {data.timeZone}
+        </p>
+      </div>
+      <Card className="min-w-0 overflow-hidden">
+        <CardHeader>
+          <div className="flex flex-wrap items-end justify-between gap-4">
+            <div>
+              <CardTitle>
+                Trade outcomes by {x === "durationMinutes" ? "holding time" : "entry time"}
+              </CardTitle>
+              <p className="mt-2 text-xs text-muted-foreground">
+                {blocked
+                  ? `${data.points.length} closed trades`
+                  : `${points.length} of ${data.points.length} closed trades comparable`}{" "}
+                · One point per trade · After fees
+              </p>
+            </div>
+            <div className="flex w-full flex-wrap gap-3 sm:w-auto">
+              <div className="min-w-0 flex-1 sm:w-44">
+                <label
+                  htmlFor="trade-x-axis"
+                  className="mb-1.5 block text-xs text-muted-foreground"
+                >
+                  X axis
+                </label>
+                <OptionSelect
+                  id="trade-x-axis"
+                  value={x}
+                  onValueChange={(value) => {
+                    setX(value as TradeXAxis);
+                    setSelected(null);
+                    setPage(0);
+                  }}
+                >
+                  <option value="durationMinutes">Duration (minutes)</option>
+                  <option value="entryMinute">Entry time</option>
+                </OptionSelect>
+              </div>
+              <div className="min-w-0 flex-1 sm:w-44">
+                <label
+                  htmlFor="trade-y-axis"
+                  className="mb-1.5 block text-xs text-muted-foreground"
+                >
+                  Y axis
+                </label>
+                <OptionSelect
+                  id="trade-y-axis"
+                  value={y}
+                  onValueChange={(value) => {
+                    setY(value as TradeYAxis);
+                    setSelected(null);
+                    setPage(0);
+                  }}
+                >
+                  <option value="netPnl">Net P&L</option>
+                  <option value="realizedR">Realized R</option>
+                </OptionSelect>
+              </div>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {data.points.length === 0 ? (
+            <div className="py-10 text-center">
+              <h3 className="font-medium">No closed trades in this selection</h3>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Change the date range or filters to explore your history. Open positions are
+                excluded.
+              </p>
+            </div>
+          ) : blocked ? (
+            <p role="note" className="rounded-lg bg-muted/30 p-4 text-sm text-muted-foreground">
+              These trades use different currencies ({data.currencies.join(", ")}). Select accounts
+              with one currency for net P&L, or choose Realized R to compare risk-normalized
+              outcomes. No currency conversion is applied.
+            </p>
+          ) : (
+            <>
+              {points.length < data.points.length && (
+                <p role="note" className="text-xs leading-relaxed text-muted-foreground">
+                  {data.points.length - points.length} trades excluded:{" "}
+                  {y === "realizedR"
+                    ? "realized R requires a valid planned stop-loss and any required contract multiplier; "
+                    : ""}
+                  both axes require valid recorded values and timestamps.
+                </p>
+              )}
+              {y === "realizedR" && (
+                <p className="text-xs leading-relaxed text-muted-foreground">
+                  R = net P&L ÷ planned risk from your stop-loss. Uses weighted entry and total
+                  entry quantity; it does not measure maximum intratrade risk.
+                </p>
+              )}
+              {points.length >= 8 ? (
+                <>
+                  <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
+                    <span>{yTitle}</span>
+                    <span className="flex flex-wrap gap-x-4 gap-y-1">
+                      <span>
+                        <span aria-hidden="true" className="text-[var(--profit)]">
+                          ●
+                        </span>{" "}
+                        Positive
+                      </span>
+                      <span>
+                        <span aria-hidden="true" className="text-[var(--loss)]">
+                          ●
+                        </span>{" "}
+                        Negative
+                      </span>
+                      <span>
+                        <span aria-hidden="true">●</span> Zero
+                      </span>
+                    </span>
+                  </div>
+                  <TradeScatter
+                    points={points}
+                    x={x}
+                    y={y}
+                    currency={currency}
+                    timeZone={data.timeZone}
+                    onSelect={setSelected}
+                  />
+                  <p className="text-center text-xs text-muted-foreground">{xTitle}</p>
+                  <p className="text-xs text-muted-foreground">
+                    Select a point to inspect its trade. Overlapping points remain individually
+                    accessible in the table.
+                  </p>
+                  <div aria-live="polite">
+                    {selected && (
+                      <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border bg-muted/20 p-4">
+                        <div>
+                          <p className="text-sm font-medium break-all">
+                            {selected.symbol} · {selected.direction} · {value(selected)}
+                          </p>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {xValue(selected)} · Closed {date.format(new Date(selected.closedAt))}
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-3">
+                          <Link
+                            href={detailHref(selected.key)}
+                            className="rounded text-sm underline underline-offset-4"
+                          >
+                            Open trade ↗
+                          </Link>
+                          <Button size="sm" variant="ghost" onClick={() => setSelected(null)}>
+                            Dismiss
+                          </Button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </>
+              ) : (
+                <p className="rounded-lg bg-muted/30 px-4 py-6 text-sm text-muted-foreground">
+                  {points.length === 0
+                    ? "No trades have the data required for these axes. Try another axis or adjust your filters."
+                    : "Fewer than 8 comparable trades. Review the exact values below, or widen your filters to reveal a useful scatter plot."}
+                </p>
+              )}
+              {points.length >= 8 && points.length < 20 && (
+                <p className="text-xs text-muted-foreground">
+                  Small sample: treat apparent patterns cautiously until more trades are available.
+                </p>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+      {!blocked &&
+        points.length > 0 &&
+        (points.length < 8 ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>Comparable trades</CardTitle>
+            </CardHeader>
+            {table}
+          </Card>
+        ) : (
+          <details
+            className="rounded-xl border bg-card"
+            onToggle={(event) => setTableOpen(event.currentTarget.open)}
+          >
+            <summary className="cursor-pointer rounded-xl px-4 py-3 text-sm font-medium">
+              Explore all {points.length} trades
+            </summary>
+            {tableOpen && table}
+          </details>
+        ))}
+      <p className="text-xs leading-relaxed text-muted-foreground">
+        Duration is elapsed time from first entry to final exit, including overnight hours. Entry
+        time uses the journal timezone; midnight neighbors appear at opposite ends of that axis.
+        Patterns describe this selection, not causation or a recommended holding time.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -1,7 +1,10 @@
+"use client";
+
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
+import { HoverHint } from "./tooltip";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
@@ -32,10 +35,19 @@ function Button({
   variant,
   size,
   asChild = false,
+  title,
   ...props
 }: React.ComponentProps<"button"> & VariantProps<typeof buttonVariants> & { asChild?: boolean }) {
   const Comp = asChild ? Slot : "button";
-  return <Comp className={cn(buttonVariants({ variant, size, className }))} {...props} />;
+  const hint = title || (size === "icon" ? props["aria-label"] : undefined);
+  const button = (
+    <Comp
+      aria-label={props["aria-label"] ?? (size === "icon" ? title : undefined)}
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+  return hint ? <HoverHint content={hint}>{button}</HoverHint> : button;
 }
 
 export { Button, buttonVariants };

--- a/apps/web/src/components/ui/calendar.tsx
+++ b/apps/web/src/components/ui/calendar.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { DayPicker, type DayPickerProps } from "react-day-picker";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+export function Calendar(props: DayPickerProps) {
+  return (
+    <DayPicker
+      showOutsideDays
+      fixedWeeks
+      className="journal-date-calendar"
+      classNames={{
+        months: "relative",
+        month_caption: "flex h-9 items-center justify-center px-10 mb-3",
+        caption_label: "text-sm font-medium tracking-tight",
+        nav: "absolute inset-x-0 top-0 flex justify-between",
+        button_previous: "journal-calendar-nav",
+        button_next: "journal-calendar-nav",
+        month_grid: "w-full table-fixed border-collapse",
+        weekday: "h-8 text-center text-[11px] font-medium text-muted-foreground",
+        day: "p-0.5 text-center",
+        day_button: "journal-calendar-date",
+        selected: "journal-date-selected",
+        today: "journal-date-today",
+        outside: "journal-date-outside",
+        disabled: "opacity-30",
+        hidden: "invisible",
+      }}
+      components={{
+        Chevron: ({ orientation }) =>
+          orientation === "left" ? (
+            <ChevronLeft className="size-4" />
+          ) : (
+            <ChevronRight className="size-4" />
+          ),
+      }}
+      {...props}
+    />
+  );
+}

--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -2,20 +2,29 @@
 
 import * as React from "react";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
-import { Check } from "lucide-react";
+import { Check, Minus } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
   return (
     <CheckboxPrimitive.Root
       className={cn(
-        "peer h-4 w-4 shrink-0 rounded-sm border border-input shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+        "peer group/checkbox size-4 shrink-0 rounded-[5px] border border-muted-foreground/50 bg-background shadow-xs transition-[background-color,border-color,box-shadow] duration-150 hover:border-foreground/70 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/35 focus-visible:border-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=indeterminate]:border-primary data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground aria-invalid:border-destructive motion-reduce:transition-none",
         className,
       )}
       {...props}
     >
       <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
-        <Check className="h-3.5 w-3.5" />
+        <Check
+          aria-hidden="true"
+          strokeWidth={3}
+          className="size-3 group-data-[state=indeterminate]/checkbox:hidden"
+        />
+        <Minus
+          aria-hidden="true"
+          strokeWidth={3}
+          className="hidden size-3 group-data-[state=indeterminate]/checkbox:block"
+        />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   );

--- a/apps/web/src/components/ui/date-picker.tsx
+++ b/apps/web/src/components/ui/date-picker.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useId, useState } from "react";
+import dynamic from "next/dynamic";
+import * as Popover from "@radix-ui/react-popover";
+import { CalendarDays } from "lucide-react";
+import { Input } from "./input";
+import { Button } from "./button";
+import { formatDateInput, parseDateInput } from "@/lib/date-input";
+
+// The calendar is loaded on demand, not in every page's initial filter-bar bundle.
+const Calendar = dynamic(() => import("./calendar").then((module) => module.Calendar), {
+  loading: () => <div role="status" aria-label="Loading calendar" className="h-[300px]" />,
+});
+
+export function DatePicker({
+  value,
+  onValueChange,
+  label,
+  min,
+  max,
+  disabled,
+}: {
+  value: string;
+  onValueChange: (value: string) => void;
+  label: string;
+  min?: string;
+  max?: string;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const [invalid, setInvalid] = useState(false);
+  const errorId = useId();
+  useEffect(() => {
+    setDraft(value);
+    setInvalid(false);
+  }, [value]);
+  const allowed = (date: string) => (!min || date >= min) && (!max || date <= max);
+  const select = (date: string) => {
+    setDraft(date);
+    setInvalid(false);
+    onValueChange(date);
+    setOpen(false);
+  };
+  const today = formatDateInput(new Date());
+  const selected = parseDateInput(value);
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Anchor asChild>
+        <span className="relative block min-w-0">
+          <Input
+            value={draft}
+            aria-label={label}
+            aria-invalid={invalid || undefined}
+            aria-describedby={invalid ? errorId : undefined}
+            placeholder="YYYY-MM-DD"
+            disabled={disabled}
+            className="journal-date-input pr-10 tabular-nums"
+            onChange={(event) => {
+              const next = event.target.value;
+              setDraft(next);
+              setInvalid(false);
+              if (!next || (parseDateInput(next) && allowed(next))) onValueChange(next);
+            }}
+            onBlur={() => setInvalid(Boolean(draft && (!parseDateInput(draft) || !allowed(draft))))}
+            onKeyDown={(event) => {
+              if (event.key === "ArrowDown") {
+                event.preventDefault();
+                setOpen(true);
+              }
+              if (event.key === "Escape") {
+                setDraft(value);
+                setInvalid(false);
+              }
+            }}
+          />
+          <Popover.Trigger asChild>
+            <button
+              type="button"
+              disabled={disabled}
+              aria-label={`Choose ${label.toLowerCase()} date`}
+              className="absolute top-0 right-0 flex size-9 items-center justify-center rounded-r-md text-muted-foreground outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+            >
+              <CalendarDays aria-hidden="true" className="size-4" />
+            </button>
+          </Popover.Trigger>
+          {invalid && (
+            <span id={errorId} role="alert" className="mt-1 block text-xs text-destructive">
+              Enter a valid date (YYYY-MM-DD){max ? ` on or before ${max}` : ""}
+              {min ? ` on or after ${min}` : ""}.
+            </span>
+          )}
+        </span>
+      </Popover.Anchor>
+      <Popover.Portal>
+        <Popover.Content
+          aria-label={`${label} calendar`}
+          align="start"
+          sideOffset={8}
+          collisionPadding={12}
+          className="journal-popup journal-menu-surface z-50 w-[296px] max-w-[calc(100vw-24px)] max-h-[var(--radix-popover-content-available-height)] overflow-y-auto rounded-xl border bg-popover p-3 text-popover-foreground outline-none"
+        >
+          <Calendar
+            mode="single"
+            autoFocus
+            selected={selected}
+            defaultMonth={selected ?? parseDateInput(max ?? "") ?? new Date()}
+            onSelect={(date) => select(date ? formatDateInput(date) : "")}
+            disabled={(date) => !allowed(formatDateInput(date))}
+          />
+          <div className="mt-3 flex items-center justify-between border-t pt-2">
+            <Button variant="ghost" size="sm" disabled={!draft} onClick={() => select("")}>
+              Clear
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={!allowed(today)}
+              onClick={() => select(today)}
+            >
+              Today
+            </Button>
+          </div>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -15,10 +15,10 @@ function DialogContent({
 }: React.ComponentProps<typeof DialogPrimitive.Content>) {
   return (
     <DialogPrimitive.Portal>
-      <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/60 data-[state=open]:animate-in data-[state=open]:fade-in-0" />
+      <DialogPrimitive.Overlay className="journal-popup fixed inset-0 z-50 bg-black/60" />
       <DialogPrimitive.Content
         className={cn(
-          "journal-dialog fixed left-1/2 top-1/2 z-50 grid w-[calc(100%-24px)] min-w-0 max-w-lg max-h-[calc(100dvh-24px)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto overscroll-contain rounded-xl border bg-card p-4 shadow-lg duration-200 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:p-6",
+          "journal-dialog journal-popup fixed left-1/2 top-1/2 z-50 grid w-[calc(100%-24px)] min-w-0 max-w-lg max-h-[calc(100dvh-24px)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto overscroll-contain rounded-xl border bg-card p-4 shadow-lg sm:p-6",
           className,
         )}
         {...props}

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import * as Menu from "@radix-ui/react-dropdown-menu";
+import type { ComponentProps } from "react";
+import { cn } from "@/lib/utils";
+
+export const DropdownMenu = Menu.Root;
+export const DropdownMenuTrigger = Menu.Trigger;
+export function DropdownMenuContent({ className, ...props }: ComponentProps<typeof Menu.Content>) {
+  return (
+    <Menu.Portal>
+      <Menu.Content
+        sideOffset={6}
+        collisionPadding={12}
+        className={cn(
+          "journal-popup journal-menu-surface z-50 min-w-48 max-w-[calc(100vw-24px)] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto rounded-xl border bg-popover p-1.5 text-popover-foreground outline-none",
+          className,
+        )}
+        {...props}
+      />
+    </Menu.Portal>
+  );
+}
+export function DropdownMenuItem({ className, ...props }: ComponentProps<typeof Menu.Item>) {
+  return (
+    <Menu.Item
+      className={cn(
+        "flex min-h-8 cursor-default select-none items-center gap-2 rounded-md px-2.5 py-1.5 text-sm outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/apps/web/src/components/ui/option-select.tsx
+++ b/apps/web/src/components/ui/option-select.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Children, isValidElement, type ComponentProps, type ReactNode } from "react";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./select";
+
+type Props = Omit<ComponentProps<typeof SelectTrigger>, "value" | "onChange" | "children"> & {
+  value: string;
+  onValueChange: (value: string) => void;
+  children: ReactNode;
+};
+
+/** Retains declarative option lists, with Radix keyboard navigation and typeahead. */
+export function OptionSelect({ value, onValueChange, children, disabled, ...props }: Props) {
+  const options = Children.toArray(children).flatMap((child) => {
+    if (!isValidElement<ComponentProps<"option">>(child)) return [];
+    return [
+      {
+        value: String(child.props.value ?? child.props.children),
+        label: child.props.children,
+        disabled: child.props.disabled,
+      },
+    ];
+  });
+  // Encode every option, including the empty-string "All" choice. Radix reserves
+  // the empty string for placeholders, not selectable items.
+  const encode = (option: string) => `option:${option}`;
+  return (
+    <Select
+      value={encode(value)}
+      onValueChange={(next) => onValueChange(next.slice(7))}
+      disabled={disabled}
+    >
+      <SelectTrigger {...props}>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((option) => (
+          <SelectItem key={option.value} value={encode(option.value)} disabled={option.disabled}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
-import { Check, ChevronDown } from "lucide-react";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const Select = SelectPrimitive.Root;
@@ -16,7 +16,7 @@ function SelectTrigger({
   return (
     <SelectPrimitive.Trigger
       className={cn(
-        "flex h-9 w-full min-w-0 items-center justify-between gap-2 whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+        "flex h-9 w-full min-w-0 items-center justify-between gap-2 whitespace-nowrap rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground shadow-xs transition-[border-color,box-shadow,background-color] hover:bg-accent/40 focus:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/25 focus-visible:border-ring data-[state=open]:border-ring/60 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:truncate motion-reduce:transition-none",
         className,
       )}
       {...props}
@@ -33,20 +33,30 @@ function SelectContent({
   className,
   children,
   position = "popper",
+  sideOffset = 6,
+  collisionPadding = 12,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {
   return (
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
         className={cn(
-          "relative z-50 max-h-[min(24rem,var(--radix-select-content-available-height))] min-w-[8rem] max-w-[calc(100vw-24px)] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
-          position === "popper" && "data-[side=bottom]:translate-y-1",
+          "journal-popup journal-menu-surface relative z-50 max-h-[min(24rem,var(--radix-select-content-available-height))] min-w-[8rem] max-w-[calc(100vw-24px)] overflow-hidden rounded-xl border bg-popover text-popover-foreground",
+          position === "popper" && "min-w-[var(--radix-select-trigger-width)]",
           className,
         )}
         position={position}
+        sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
         {...props}
       >
-        <SelectPrimitive.Viewport className="p-1">{children}</SelectPrimitive.Viewport>
+        <SelectPrimitive.ScrollUpButton className="flex h-6 items-center justify-center bg-popover text-muted-foreground">
+          <ChevronUp className="size-3.5" />
+        </SelectPrimitive.ScrollUpButton>
+        <SelectPrimitive.Viewport className="p-1.5">{children}</SelectPrimitive.Viewport>
+        <SelectPrimitive.ScrollDownButton className="flex h-6 items-center justify-center bg-popover text-muted-foreground">
+          <ChevronDown className="size-3.5" />
+        </SelectPrimitive.ScrollDownButton>
       </SelectPrimitive.Content>
     </SelectPrimitive.Portal>
   );
@@ -60,7 +70,7 @@ function SelectItem({
   return (
     <SelectPrimitive.Item
       className={cn(
-        "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        "relative flex min-h-8 w-full cursor-default select-none items-center rounded-md py-1.5 pl-2.5 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=checked]:font-medium data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>span:last-child]:break-words",
         className,
       )}
       {...props}

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { cn } from "@/lib/utils";
+import { CircleHelp } from "lucide-react";
 
 const TooltipProvider = TooltipPrimitive.Provider;
 const Tooltip = TooltipPrimitive.Root;
@@ -10,20 +11,61 @@ const TooltipTrigger = TooltipPrimitive.Trigger;
 
 function TooltipContent({
   className,
-  sideOffset = 4,
+  sideOffset = 8,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
         sideOffset={sideOffset}
+        collisionPadding={12}
         className={cn(
-          "z-50 max-w-64 rounded-md border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md",
+          "journal-hover-card z-[80] max-w-[min(19rem,calc(100vw-24px))] rounded-xl border bg-popover p-3.5 text-[13px] leading-relaxed text-popover-foreground",
           className,
         )}
         {...props}
       />
     </TooltipPrimitive.Portal>
+  );
+}
+
+/** Shared hover/focus help without an extra layout wrapper or native title bubble. */
+export function HoverHint({
+  children,
+  content,
+  heading,
+  side = "top",
+}: {
+  children: React.ReactElement;
+  content: React.ReactNode;
+  heading?: string;
+  side?: React.ComponentProps<typeof TooltipContent>["side"];
+}) {
+  if (!content) return children;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent side={side}>
+        {heading && (
+          <div className="mb-1 text-[13px] font-semibold text-popover-foreground">{heading}</div>
+        )}
+        <div className={heading ? "text-muted-foreground" : undefined}>{content}</div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function HelpHint({ heading, children }: { heading: string; children: React.ReactNode }) {
+  return (
+    <HoverHint heading={heading} content={children}>
+      <button
+        type="button"
+        aria-label={`About ${heading}`}
+        className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <CircleHelp aria-hidden="true" className="h-3.5 w-3.5" />
+      </button>
+    </HoverHint>
   );
 }
 

--- a/apps/web/src/components/voice-note.tsx
+++ b/apps/web/src/components/voice-note.tsx
@@ -98,7 +98,7 @@ export function VoiceNote({
                 onPrepare();
               }
             }}
-            className="z-50 max-h-[var(--radix-popover-content-available-height)] w-80 max-w-[calc(100vw-24px)] space-y-3 overflow-y-auto rounded-xl border bg-card p-4 text-sm shadow-lg"
+            className="journal-popup z-50 max-h-[var(--radix-popover-content-available-height)] w-80 max-w-[calc(100vw-24px)] space-y-3 overflow-y-auto rounded-xl border bg-card p-4 text-sm shadow-lg"
           >
             <p role="alert">{error}</p>
             <p className="text-muted-foreground">

--- a/apps/web/src/lib/ai-feedback.ts
+++ b/apps/web/src/lib/ai-feedback.ts
@@ -1,0 +1,74 @@
+export interface AiFeedback {
+  title: string;
+  description: string;
+  tone: "info" | "error";
+  action?: { label: string; href: string };
+  retry?: boolean;
+}
+
+/** Friendly, bounded copy: never echo provider payloads or credentials into the UI. */
+export function aiFeedback(message: string): AiFeedback {
+  if (/AI is not configured/i.test(message))
+    return {
+      title: "Set up AI to continue",
+      description:
+        "Connect your Anthropic API key in Settings to ask questions, generate recaps, and review trades.",
+      tone: "info",
+      action: { label: "Set up AI", href: "/settings#ai-settings" },
+    };
+  if (/invalid.*(?:api.?key|x-api-key)|authentication_error|invalid x-api-key/i.test(message))
+    return {
+      title: "Check your AI connection",
+      description: "Anthropic couldn’t verify your API key. Update it in Settings, then try again.",
+      tone: "error",
+      action: { label: "Review AI settings", href: "/settings#ai-settings" },
+    };
+  if (/credit balance|billing|insufficient.*credit/i.test(message))
+    return {
+      title: "Your AI account needs attention",
+      description: "Check the billing or credit balance on your Anthropic account, then try again.",
+      tone: "info",
+    };
+  if (/rate.limit|too many requests|overloaded/i.test(message))
+    return {
+      title: "AI is temporarily busy",
+      description: "Please wait a moment before trying again. Your journal data hasn’t changed.",
+      tone: "info",
+      retry: true,
+    };
+  if (/journal is empty/i.test(message))
+    return {
+      title: "Add trades to get started",
+      description:
+        "AI insights use your journal history. Import your trades, then ask your question again.",
+      tone: "info",
+      action: { label: "Import trades", href: "/import" },
+    };
+  if (/No closed trades on this day/i.test(message))
+    return {
+      title: "No trades to recap yet",
+      description:
+        "A recap needs at least one closed trade on this day. You can still write your own day note.",
+      tone: "info",
+    };
+  if (/Unauthorized/i.test(message))
+    return {
+      title: "Please sign in again",
+      description: "Your session may have expired. Sign in to continue using your journal.",
+      tone: "info",
+      action: { label: "Sign in", href: "/login" },
+    };
+  if (/failed to fetch|network|timeout|timed out|connection/i.test(message))
+    return {
+      title: "Couldn’t connect to AI",
+      description: "Check your connection and try again. Your journal data hasn’t changed.",
+      tone: "error",
+      retry: true,
+    };
+  return {
+    title: "Couldn’t complete the AI request",
+    description: "Please try again in a moment. If this continues, check your AI settings.",
+    tone: "error",
+    retry: true,
+  };
+}

--- a/apps/web/src/lib/calendar-insights.ts
+++ b/apps/web/src/lib/calendar-insights.ts
@@ -1,0 +1,115 @@
+import {
+  readFilters,
+  type AnalysisFilters,
+  type CalendarMonth,
+  type DayStats,
+} from "@luxalgo/journal-core";
+
+export function calendarScope(filters: AnalysisFilters, year: number, month: number) {
+  const start = `${year}-${String(month).padStart(2, "0")}-01`;
+  const end = `${year}-${String(month).padStart(2, "0")}-${new Date(Date.UTC(year, month, 0)).getUTCDate()}`;
+  return {
+    ...filters,
+    from: filters.from && filters.from > start ? filters.from : start,
+    to: filters.to && filters.to < end ? filters.to : end,
+  };
+}
+
+export const closingWeekday = (date: string) => new Date(`${date}T12:00:00Z`).getUTCDay();
+
+/** Calendar cells already contain filtered, timezone-bucketed CLOSED trades. */
+export function calendarInsights(calendar: CalendarMonth) {
+  const days = calendar.weeks
+    .flatMap((week) => week.days)
+    .filter((day): day is DayStats => day !== null && day.trades > 0)
+    .sort((a, b) => a.date.localeCompare(b.date));
+  const green = days.filter((d) => d.netPnl > 0);
+  const red = days.filter((d) => d.netPnl < 0);
+  const trades = days.reduce((sum, d) => sum + d.trades, 0);
+  const wins = days.reduce((sum, d) => sum + d.wins, 0);
+  const losses = days.reduce((sum, d) => sum + d.losses, 0);
+  const breakevens = days.reduce((sum, d) => sum + d.breakevens, 0);
+  const netPnl = days.reduce((sum, d) => sum + d.netPnl, 0);
+  const weekdays = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+  ].map((label, index) => {
+    const matching = days.filter((day) => closingWeekday(day.date) === index);
+    return {
+      index,
+      label,
+      days: matching,
+      trades: matching.reduce((sum, d) => sum + d.trades, 0),
+      netPnl: matching.reduce((sum, d) => sum + d.netPnl, 0),
+    };
+  });
+  const profitableWeekdays = weekdays
+    .filter((d) => d.netPnl > 0)
+    .sort((a, b) => b.netPnl - a.netPnl || a.index - b.index);
+  return {
+    days,
+    trades,
+    wins,
+    losses,
+    breakevens,
+    netPnl,
+    tradingDays: days.length,
+    greenDays: green.length,
+    redDays: red.length,
+    flatDays: days.length - green.length - red.length,
+    winRate: trades ? wins / trades : null,
+    profitableDayRate: days.length ? green.length / days.length : null,
+    avgDailyPnl: days.length ? netPnl / days.length : null,
+    avgGreenDay: green.length ? green.reduce((sum, d) => sum + d.netPnl, 0) / green.length : null,
+    avgRedDay: red.length ? red.reduce((sum, d) => sum + d.netPnl, 0) / red.length : null,
+    // Stable tie rule: first chronological occurrence.
+    bestDay: days.reduce<DayStats | null>(
+      (best, day) => (!best || day.netPnl > best.netPnl ? day : best),
+      null,
+    ),
+    worstDay: days.reduce<DayStats | null>(
+      (worst, day) => (!worst || day.netPnl < worst.netPnl ? day : worst),
+      null,
+    ),
+    weekdays,
+    mostProfitableWeekday: profitableWeekdays[0] ?? null,
+    trend: days.map((day, index) => ({
+      ...day,
+      average:
+        index < 4
+          ? null
+          : days.slice(index - 4, index + 1).reduce((sum, d) => sum + d.netPnl, 0) / 5,
+    })),
+  };
+}
+
+export type CalendarInsights = ReturnType<typeof calendarInsights>;
+export interface CalendarResponse {
+  calendar: CalendarMonth;
+  insights: CalendarInsights;
+  timeZone: string;
+  currencies: string[];
+  scope: AnalysisFilters & { from: string; to: string };
+}
+
+/** Date drill-downs must not reuse the opening-weekday filter for closing days. */
+export function calendarTradeHref(
+  query: string,
+  scope: { from: string; to: string },
+  date?: string,
+) {
+  const filters = readFilters(new URLSearchParams(query));
+  const params = new URLSearchParams({
+    ...filters,
+    from: date ?? scope.from,
+    to: date ?? scope.to,
+    range: "custom",
+    status: filters.status ?? "closed",
+  });
+  return `/trades?${params}`;
+}

--- a/apps/web/src/lib/dashboard-drag.ts
+++ b/apps/web/src/lib/dashboard-drag.ts
@@ -1,0 +1,33 @@
+export interface DashboardDragPoint {
+  x: number;
+  y: number;
+}
+
+export interface DashboardDropRect {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Ignore the unstable outer rim of a card while pointer-dragging. Grid reflow
+ * can swap the card beneath a pointer sitting exactly on an edge; requiring a
+ * small amount of penetration makes the intended destination unambiguous.
+ */
+export function isInsideDashboardReorderZone(
+  point: DashboardDragPoint,
+  rect: DashboardDropRect,
+  inset = 18,
+) {
+  const xInset = Math.min(inset, Math.max(0, (rect.width - 1) / 2));
+  const yInset = Math.min(inset, Math.max(0, (rect.height - 1) / 2));
+  return (
+    point.x >= rect.left + xInset &&
+    point.x <= rect.right - xInset &&
+    point.y >= rect.top + yInset &&
+    point.y <= rect.bottom - yInset
+  );
+}

--- a/apps/web/src/lib/dashboard-layout.ts
+++ b/apps/web/src/lib/dashboard-layout.ts
@@ -9,6 +9,46 @@ export interface DashboardPreferences {
   layouts: Record<string, DashboardArrangement>;
 }
 
+export type DashboardCardSize = "small" | "medium" | "wide" | "full";
+
+/**
+ * Fill each responsive grid row without changing card order. Any columns left
+ * over before the next card are shared across the cards already in that row.
+ */
+export function balancedDashboardSpans(
+  cards: { id: string; size: DashboardCardSize; layoutGroup?: string }[],
+  columns: number,
+  base: Record<DashboardCardSize, number>,
+): Record<string, number> {
+  const spans: Record<string, number> = {};
+  let row: string[] = [];
+  let used = 0;
+  let group: string | undefined;
+
+  const finishRow = () => {
+    if (!row.length) return;
+    let remaining = columns - used;
+    for (let index = 0; remaining > 0; index++, remaining--)
+      spans[row[index % row.length]!] = (spans[row[index % row.length]!] ?? 0) + 1;
+    row = [];
+    used = 0;
+    group = undefined;
+  };
+
+  for (const card of cards) {
+    const span = Math.min(columns, Math.max(1, base[card.size]));
+    if (row.length && card.layoutGroup !== group) finishRow();
+    if (used + span > columns) finishRow();
+    spans[card.id] = span;
+    row.push(card.id);
+    used += span;
+    group = card.layoutGroup;
+    if (used === columns) finishRow();
+  }
+  finishRow();
+  return spans;
+}
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
 

--- a/apps/web/src/lib/date-input.ts
+++ b/apps/web/src/lib/date-input.ts
@@ -1,0 +1,15 @@
+/** Date-only values stay in local calendar time; never shift through UTC. */
+export function parseDateInput(value: string): Date | undefined {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return undefined;
+  const [year, month, day] = value.split("-").map(Number) as [number, number, number];
+  const date = new Date(0);
+  date.setFullYear(year, month - 1, day);
+  date.setHours(12, 0, 0, 0);
+  return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day
+    ? date
+    : undefined;
+}
+
+export function formatDateInput(date: Date): string {
+  return `${String(date.getFullYear()).padStart(4, "0")}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}

--- a/apps/web/src/lib/performance-trends.ts
+++ b/apps/web/src/lib/performance-trends.ts
@@ -1,0 +1,77 @@
+import type { AnnotatedTrade } from "@luxalgo/journal-core";
+
+export const ROLLING_TRADE_WINDOW = 20;
+export const MIN_TREND_POINTS = 8;
+
+export function performanceTrends(trades: AnnotatedTrade[]) {
+  const closed = trades
+    .filter((trade) => trade.status !== "open" && trade.closedAt)
+    .slice()
+    .sort(
+      (a, b) => Date.parse(a.closedAt!) - Date.parse(b.closedAt!) || a.key.localeCompare(b.key),
+    );
+  const points: {
+    sequence: number;
+    key: string;
+    closedAt: string;
+    winRate: number;
+    avgNetPnl: number;
+  }[] = [];
+  let wins = 0,
+    netPnl = 0,
+    windowWins = 0,
+    windowPnl = 0;
+  let largestWin: AnnotatedTrade | null = null,
+    largestLoss: AnnotatedTrade | null = null;
+  for (let index = 0; index < closed.length; index++) {
+    const trade = closed[index]!;
+    const win = Number(trade.status === "win");
+    wins += win;
+    netPnl += trade.netPnl;
+    windowWins += win;
+    windowPnl += trade.netPnl;
+    if (index >= ROLLING_TRADE_WINDOW) {
+      const previous = closed[index - ROLLING_TRADE_WINDOW]!;
+      windowWins -= Number(previous.status === "win");
+      windowPnl -= previous.netPnl;
+    }
+    if (trade.status === "win" && (!largestWin || trade.netPnl > largestWin.netPnl))
+      largestWin = trade;
+    if (trade.status === "loss" && (!largestLoss || trade.netPnl < largestLoss.netPnl))
+      largestLoss = trade;
+    if (index >= ROLLING_TRADE_WINDOW - 1)
+      points.push({
+        sequence: index + 1,
+        key: trade.key,
+        closedAt: trade.closedAt!,
+        winRate: windowWins / ROLLING_TRADE_WINDOW,
+        avgNetPnl: windowPnl / ROLLING_TRADE_WINDOW,
+      });
+  }
+  const detail = (trade: AnnotatedTrade | null) =>
+    trade
+      ? {
+          key: trade.key,
+          symbol: trade.symbol,
+          direction: trade.direction,
+          closedAt: trade.closedAt!,
+          netPnl: trade.netPnl,
+        }
+      : null;
+  return {
+    count: closed.length,
+    window: ROLLING_TRADE_WINDOW,
+    points,
+    overallWinRate: closed.length ? wins / closed.length : null,
+    overallAvgNetPnl: closed.length ? netPnl / closed.length : null,
+    largestWin: detail(largestWin),
+    largestLoss: detail(largestLoss),
+  };
+}
+
+export type PerformanceTrends = ReturnType<typeof performanceTrends>;
+export interface PerformanceTrendsResponse {
+  trends: PerformanceTrends;
+  currencies: string[];
+  timeZone: string;
+}

--- a/apps/web/src/lib/theme.ts
+++ b/apps/web/src/lib/theme.ts
@@ -1,0 +1,8 @@
+export type Theme = "dark" | "light";
+export const THEME_KEY = "journal-theme-v1";
+export const themePreference = (value: string | null): Theme =>
+  value === "light" ? "light" : "dark";
+
+// Runs in <head>, before the page paints. A saved light theme must not flash dark
+// while React hydrates. No OS preference override: dark is the product default.
+export const THEME_INIT_SCRIPT = `(()=>{let theme="dark";try{theme=localStorage.getItem(${JSON.stringify(THEME_KEY)})==="light"?"light":"dark"}catch{}document.documentElement.classList.toggle("dark",theme==="dark")})();`;

--- a/apps/web/src/lib/trade-explorer.ts
+++ b/apps/web/src/lib/trade-explorer.ts
@@ -1,0 +1,57 @@
+import { clockTime, tradeR, type AnnotatedTrade } from "@luxalgo/journal-core";
+
+export type TradeXAxis = "durationMinutes" | "entryMinute";
+export type TradeYAxis = "netPnl" | "realizedR";
+export interface TradePoint {
+  key: string;
+  symbol: string;
+  direction: string;
+  closedAt: string;
+  durationMinutes: number | null;
+  entryMinute: number | null;
+  netPnl: number | null;
+  realizedR: number | null;
+}
+export interface TradeExplorerResponse {
+  points: TradePoint[];
+  currencies: string[];
+  timeZone: string;
+}
+const finite = (value: number | null): number | null =>
+  value !== null && Number.isFinite(value) ? value : null;
+
+export function tradeExplorerPoints(trades: AnnotatedTrade[], timeZone: string): TradePoint[] {
+  return trades
+    .filter((trade) => trade.status !== "open" && trade.closedAt)
+    .map((trade) => {
+      const opened = Date.parse(trade.openedAt),
+        closed = Date.parse(trade.closedAt!);
+      const elapsed = (closed - opened) / 60000;
+      const clock = Number.isFinite(opened)
+        ? clockTime(trade.openedAt, timeZone).split(":").map(Number)
+        : null;
+      return {
+        key: trade.key,
+        symbol: trade.symbol,
+        direction: trade.direction,
+        closedAt: trade.closedAt!,
+        durationMinutes: Number.isFinite(elapsed) && elapsed >= 0 ? elapsed : null,
+        entryMinute: clock ? finite(clock[0]! * 60 + clock[1]!) : null,
+        netPnl: finite(trade.netPnl),
+        realizedR: finite(tradeR(trade)),
+      };
+    })
+    .sort((a, b) => Date.parse(b.closedAt) - Date.parse(a.closedAt) || a.key.localeCompare(b.key));
+}
+
+export function plotTradePoints(points: TradePoint[], x: TradeXAxis, y: TradeYAxis) {
+  return points.flatMap((point) =>
+    point[x] === null || point[y] === null || !Number.isFinite(Date.parse(point.closedAt))
+      ? []
+      : [{ ...point, x: point[x]!, y: point[y]! }],
+  );
+}
+export type PlottedTrade = ReturnType<typeof plotTradePoints>[number];
+
+export const clockLabel = (minute: number) =>
+  `${String(Math.floor(minute / 60)).padStart(2, "0")}:${String(Math.round(minute % 60)).padStart(2, "0")}`;

--- a/apps/web/src/lib/use-api.ts
+++ b/apps/web/src/lib/use-api.ts
@@ -36,16 +36,15 @@ export const useApi = <T>(url: string | null): ApiState<T> => {
         setData(body);
         setDataUrl(url);
         setError(null);
+        setLoading(false);
       })
       .catch((cause: unknown) => {
         if (!cancelled) {
           setError(cause instanceof Error ? cause.message : "Network error");
           setData(null);
           setDataUrl(url);
+          setLoading(false);
         }
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
       });
     return () => {
       cancelled = true;

--- a/apps/web/tests/ai-feedback.test.ts
+++ b/apps/web/tests/ai-feedback.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { aiFeedback } from "../src/lib/ai-feedback";
+
+describe("AI feedback", () => {
+  it("treats missing setup as guidance with a direct settings destination", () => {
+    expect(
+      aiFeedback(
+        "AI is not configured — add your Anthropic API key in Settings (it stays on your machine).",
+      ),
+    ).toMatchObject({
+      tone: "info",
+      title: "Set up AI to continue",
+      action: { href: "/settings#ai-settings" },
+    });
+  });
+  it("distinguishes credentials, billing and temporary provider failures", () => {
+    expect(aiFeedback("authentication_error: invalid x-api-key").action?.label).toBe(
+      "Review AI settings",
+    );
+    expect(aiFeedback("Your credit balance is too low").title).toBe(
+      "Your AI account needs attention",
+    );
+    expect(aiFeedback("rate_limit_error")).toMatchObject({ tone: "info", retry: true });
+    expect(aiFeedback("overloaded_error").retry).toBe(true);
+  });
+  it("offers data-specific empty-state guidance without an unhelpful retry", () => {
+    expect(aiFeedback("The journal is empty — import trades first").action?.href).toBe("/import");
+    const recap = aiFeedback("No closed trades on this day to recap");
+    expect(recap.title).toBe("No trades to recap yet");
+    expect(recap.retry).toBeUndefined();
+  });
+  it("offers recovery for network and session failures", () => {
+    expect(aiFeedback("Failed to fetch")).toMatchObject({
+      title: "Couldn’t connect to AI",
+      retry: true,
+    });
+    expect(aiFeedback("Unauthorized").action?.href).toBe("/login");
+  });
+  it("never echoes raw provider payloads or credentials into the notice", () => {
+    const raw = 'Provider error: {secret: "sk-ant-PRIVATE", prompt: "PRIVATE JOURNAL"}';
+    const notice = aiFeedback(raw);
+    expect(notice.title).toBe("Couldn’t complete the AI request");
+    expect(JSON.stringify(notice)).not.toContain("PRIVATE");
+    expect(notice.retry).toBe(true);
+  });
+});

--- a/apps/web/tests/calendar-insights.test.ts
+++ b/apps/web/tests/calendar-insights.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRoundTrips,
+  calendarMonthFromDays,
+  dailyStats,
+  matchesFilters,
+  type AnnotatedTrade,
+  type DayStats,
+} from "@luxalgo/journal-core";
+import { calendarInsights, calendarScope, calendarTradeHref } from "../src/lib/calendar-insights";
+
+const day = (date: string, netPnl: number): DayStats => ({
+  date,
+  netPnl,
+  grossPnl: netPnl + 1,
+  fees: 1,
+  trades: 2,
+  wins: netPnl > 0 ? 1 : 0,
+  losses: netPnl > 0 ? 1 : netPnl < 0 ? 2 : 0,
+  breakevens: netPnl === 0 ? 2 : 0,
+  volume: 10,
+});
+const days = [100, -40, 0, 60, -20, 10, 20, 30].map((pnl, index) =>
+  day(`2026-09-0${index + 1}`, pnl),
+);
+
+describe("calendar performance calculations", () => {
+  it("reconciles totals with the calendar and distinguishes trade/day denominators", () => {
+    const calendar = calendarMonthFromDays(days, 2026, 9);
+    const i = calendarInsights(calendar);
+    expect(i.netPnl).toBe(calendar.monthNetPnl);
+    expect(i.trades).toBe(calendar.monthTrades);
+    expect(i.tradingDays).toBe(calendar.tradingDays);
+    expect(i).toMatchObject({
+      netPnl: 160,
+      trades: 16,
+      tradingDays: 8,
+      wins: 5,
+      losses: 9,
+      breakevens: 2,
+      avgDailyPnl: 20,
+      avgGreenDay: 44,
+      avgRedDay: -30,
+      greenDays: 5,
+      redDays: 2,
+      flatDays: 1,
+      winRate: 5 / 16,
+      profitableDayRate: 5 / 8,
+    });
+    expect(i.bestDay?.date).toBe("2026-09-01");
+    expect(i.worstDay?.date).toBe("2026-09-02");
+    expect(i.weekdays.reduce((sum, bucket) => sum + bucket.netPnl, 0)).toBe(i.netPnl);
+    expect(i.weekdays.reduce((sum, bucket) => sum + bucket.trades, 0)).toBe(i.trades);
+    expect(i.mostProfitableWeekday?.label).toBe("Tuesday");
+    expect(i.trend.map((d) => d.average)).toEqual([null, null, null, null, 20, 2, 14, 20]);
+  });
+  it("does not pad trading-day averages with no-trade days or other months", () => {
+    const i = calendarInsights(
+      calendarMonthFromDays([day("2026-08-31", 10000), day("2026-09-04", 40)], 2026, 9),
+    );
+    expect(i.tradingDays).toBe(1);
+    expect(i.avgDailyPnl).toBe(40);
+    expect(i.bestDay).toEqual(i.worstDay);
+    expect(i.avgRedDay).toBeNull();
+  });
+  it("returns null rates and extrema for empty selections", () => {
+    const i = calendarInsights(calendarMonthFromDays([], 2026, 9));
+    expect(i).toMatchObject({
+      trades: 0,
+      tradingDays: 0,
+      avgDailyPnl: null,
+      winRate: null,
+      profitableDayRate: null,
+      bestDay: null,
+      worstDay: null,
+      mostProfitableWeekday: null,
+    });
+  });
+  it("handles all losing, all flat, and tied days honestly", () => {
+    const loss = calendarInsights(
+      calendarMonthFromDays([day("2026-09-01", -10), day("2026-09-02", -10)], 2026, 9),
+    );
+    expect(loss.mostProfitableWeekday).toBeNull();
+    expect(loss.avgGreenDay).toBeNull();
+    expect(loss.profitableDayRate).toBe(0);
+    expect(loss.bestDay?.date).toBe("2026-09-01");
+    const flat = calendarInsights(calendarMonthFromDays([day("2026-09-01", 0)], 2026, 9));
+    expect(flat).toMatchObject({
+      avgDailyPnl: 0,
+      flatDays: 1,
+      avgGreenDay: null,
+      avgRedDay: null,
+      profitableDayRate: 0,
+    });
+  });
+});
+
+describe("calendar scope and drill-down", () => {
+  it("intersects month/range, including leap years and non-overlapping selections", () => {
+    expect(
+      calendarScope({ accounts: "a", from: "2024-02-10", to: "2024-03-10", tag: "plan" }, 2024, 2),
+    ).toEqual({ accounts: "a", from: "2024-02-10", to: "2024-02-29", tag: "plan" });
+    const empty = calendarScope({ from: "2026-10-01" }, 2026, 9);
+    expect(empty.from > empty.to).toBe(true);
+    expect(calendarScope({}, 2026, 12)).toEqual({ from: "2026-12-01", to: "2026-12-31" });
+  });
+  it("preserves account, outcomes and entry-weekday filters when linking a closing day", () => {
+    const url = new URL(
+      calendarTradeHref(
+        "accounts=a&weekdays=1&tag=plan&status=win&range=7d",
+        { from: "2026-09-01", to: "2026-09-30" },
+        "2026-09-08",
+      ),
+      "http://localhost",
+    );
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      accounts: "a",
+      from: "2026-09-08",
+      to: "2026-09-08",
+      tag: "plan",
+      status: "win",
+      weekdays: "1",
+      range: "custom",
+    });
+    expect(
+      new URL(
+        calendarTradeHref("", { from: "2026-09-01", to: "2026-09-30" }),
+        "http://localhost",
+      ).searchParams.get("status"),
+    ).toBe("closed");
+  });
+  it("uses journal timezone and closing weekday across a month boundary, excluding open positions", () => {
+    const base = buildRoundTrips([
+      {
+        id: "entry",
+        accountId: "a",
+        symbol: "TEST",
+        side: "buy",
+        quantity: 10,
+        price: 10,
+        fee: 2,
+        executedAt: "2026-08-30T12:00:00Z",
+        source: "manual",
+      },
+      {
+        id: "exit",
+        accountId: "a",
+        symbol: "TEST",
+        side: "sell",
+        quantity: 10,
+        price: 20,
+        fee: 2,
+        executedAt: "2026-09-01T00:30:00Z",
+        source: "manual",
+      },
+    ])[0]!;
+    const trades: AnnotatedTrade[] = [
+      base,
+      { ...base, key: "other", accountId: "b", netPnl: 500 },
+      { ...base, key: "open", status: "open", closedAt: undefined, netPnl: 999 },
+    ];
+    const filters = calendarScope({ accounts: "a", symbol: "TEST", direction: "long" }, 2026, 8);
+    const ny = trades.filter((t) => matchesFilters(t, filters, "America/New_York"));
+    const i = calendarInsights(calendarMonthFromDays(dailyStats(ny, "America/New_York"), 2026, 8));
+    expect(i).toMatchObject({ trades: 1, netPnl: 96 });
+    expect(i.bestDay?.date).toBe("2026-08-31");
+    expect(i.mostProfitableWeekday?.label).toBe("Monday");
+    expect(
+      calendarInsights(
+        calendarMonthFromDays(
+          dailyStats(
+            trades.filter((t) => matchesFilters(t, filters, "UTC")),
+            "UTC",
+          ),
+          2026,
+          8,
+        ),
+      ).trades,
+    ).toBe(0);
+  });
+});

--- a/apps/web/tests/dashboard-layout.test.ts
+++ b/apps/web/tests/dashboard-layout.test.ts
@@ -1,10 +1,28 @@
 import { describe, expect, it } from "vitest";
 import {
+  balancedDashboardSpans,
   moveDashboardCard,
   normalizeArrangement,
   readDashboardPreferences,
   visibleCardIds,
 } from "../src/lib/dashboard-layout";
+import { isInsideDashboardReorderZone } from "../src/lib/dashboard-drag";
+
+describe("dashboard drag stability", () => {
+  const rect = { left: 100, right: 300, top: 200, bottom: 400, width: 200, height: 200 };
+
+  it("ignores the unstable rim around a drop target", () => {
+    expect(isInsideDashboardReorderZone({ x: 101, y: 300 }, rect)).toBe(false);
+    expect(isInsideDashboardReorderZone({ x: 299, y: 300 }, rect)).toBe(false);
+    expect(isInsideDashboardReorderZone({ x: 200, y: 201 }, rect)).toBe(false);
+    expect(isInsideDashboardReorderZone({ x: 200, y: 399 }, rect)).toBe(false);
+  });
+
+  it("accepts deliberate movement into the target", () => {
+    expect(isInsideDashboardReorderZone({ x: 118, y: 218 }, rect)).toBe(true);
+    expect(isInsideDashboardReorderZone({ x: 200, y: 300 }, rect)).toBe(true);
+  });
+});
 
 describe("dashboard layout persistence", () => {
   const ids = ["net", "win", "edge", "calendar", "activity"];
@@ -66,5 +84,28 @@ describe("dashboard layout persistence", () => {
     const current = { order: ids, hidden: ["win"] };
     for (const to of ["net", "win", "not-a-card"])
       expect(moveDashboardCard(current, "net", to)).toBe(current);
+  });
+
+  it("balances responsive rows without reordering cards", () => {
+    const cards = [
+      { id: "a", size: "small" as const, layoutGroup: "summary" },
+      { id: "b", size: "small" as const, layoutGroup: "summary" },
+      { id: "c", size: "small" as const, layoutGroup: "summary" },
+      { id: "chart", size: "medium" as const, layoutGroup: "visuals" },
+    ];
+    expect(balancedDashboardSpans(cards, 6, { small: 2, medium: 2, wide: 4, full: 6 })).toEqual({
+      a: 2,
+      b: 2,
+      c: 2,
+      chart: 6,
+    });
+    expect(
+      balancedDashboardSpans(cards.slice(0, 2), 6, {
+        small: 2,
+        medium: 6,
+        wide: 6,
+        full: 6,
+      }),
+    ).toEqual({ a: 3, b: 3 });
   });
 });

--- a/apps/web/tests/date-input.test.ts
+++ b/apps/web/tests/date-input.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { formatDateInput, parseDateInput } from "../src/lib/date-input";
+
+describe("date-only picker values", () => {
+  it("round trips dates without converting through UTC", () => {
+    for (const value of ["2026-09-04", "2024-02-29", "2026-12-31", "0099-01-01"]) {
+      expect(formatDateInput(parseDateInput(value)!)).toBe(value);
+    }
+  });
+  it("rejects impossible and partial dates", () => {
+    for (const value of [
+      "",
+      "2026-02-29",
+      "2026-04-31",
+      "2026-13-01",
+      "2026-00-01",
+      "2026-09-00",
+      "2026-9-1",
+      "09/04/2026",
+    ]) {
+      expect(parseDateInput(value)).toBeUndefined();
+    }
+  });
+});

--- a/apps/web/tests/performance-trends.test.ts
+++ b/apps/web/tests/performance-trends.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { matchesFilters, type AnnotatedTrade } from "@luxalgo/journal-core";
+import { performanceTrends } from "../src/lib/performance-trends";
+
+const trade = (
+  index: number,
+  netPnl: number,
+  patch: Partial<AnnotatedTrade> = {},
+): AnnotatedTrade => ({
+  key: `trade-${String(index).padStart(3, "0")}`,
+  accountId: "a",
+  symbol: "AAPL",
+  direction: "long",
+  status: netPnl > 0 ? "win" : netPnl < 0 ? "loss" : "breakeven",
+  openedAt: new Date(Date.UTC(2026, 7, index + 1, 12)).toISOString(),
+  closedAt: new Date(Date.UTC(2026, 7, index + 1, 13)).toISOString(),
+  quantity: 1,
+  openQuantity: 0,
+  avgEntry: 100,
+  avgExit: 100 + netPnl + 2,
+  grossPnl: netPnl + 2,
+  fees: 2,
+  netPnl,
+  executionCount: 2,
+  executionIds: [],
+  exits: [],
+  ...patch,
+});
+
+describe("performance trends", () => {
+  it("has honest empty and sparse states without partial windows", () => {
+    expect(performanceTrends([])).toMatchObject({
+      count: 0,
+      points: [],
+      overallWinRate: null,
+      overallAvgNetPnl: null,
+      largestWin: null,
+      largestLoss: null,
+    });
+    const result = performanceTrends(Array.from({ length: 19 }, (_, i) => trade(i, 10)));
+    expect(result.points).toEqual([]);
+    expect(result.overallAvgNetPnl).toBe(10);
+    expect(result.overallWinRate).toBe(1);
+  });
+  it("computes full trailing windows after fees including breakevens in win-rate denominator", () => {
+    const values = Array.from({ length: 32 }, (_, i) => [10, -4, 0, 6][i % 4]!);
+    const trades = values.map((value, i) => trade(i, value));
+    const result = performanceTrends(trades);
+    expect(result.points).toHaveLength(13);
+    result.points.forEach((point, index) => {
+      const window = values.slice(index, index + 20);
+      expect(point.sequence).toBe(index + 20);
+      expect(point.winRate).toBe(window.filter((value) => value > 0).length / 20);
+      expect(point.avgNetPnl).toBeCloseTo(window.reduce((a, b) => a + b, 0) / 20);
+      expect(point.key).toBe(trades[index + 19]!.key);
+    });
+    expect(result.overallWinRate).toBe(0.5);
+    expect(result.overallAvgNetPnl).toBe(3);
+  });
+  it("sorts by closing time deterministically, excludes open trades, and does not mutate input", () => {
+    const input = [trade(2, -7), trade(0, 5), trade(1, 4, { closedAt: undefined, status: "open" })];
+    const before = structuredClone(input);
+    expect(performanceTrends(input)).toMatchObject({
+      count: 2,
+      overallAvgNetPnl: -1,
+      overallWinRate: 0.5,
+    });
+    expect(input).toEqual(before);
+    const tied = [trade(2, 8, { closedAt: input[1]!.closedAt }), input[1]!];
+    expect(performanceTrends(tied).largestWin?.key).toBe("trade-002");
+  });
+  it("links extrema to actual trades and resolves equal amounts to earliest close", () => {
+    const input = [trade(5, -10), trade(3, 12), trade(2, 12), trade(1, -10)];
+    expect(performanceTrends(input)).toMatchObject({
+      largestWin: { key: "trade-002", netPnl: 12 },
+      largestLoss: { key: "trade-001", netPnl: -10 },
+    });
+    expect(performanceTrends([trade(0, 0)])).toMatchObject({
+      largestWin: null,
+      largestLoss: null,
+      overallWinRate: 0,
+    });
+    expect(performanceTrends([trade(0, 12)]).largestLoss).toBeNull();
+    expect(performanceTrends([trade(0, -12)]).largestWin).toBeNull();
+  });
+  it("honors configured outcome classification rather than deriving wins from the sign", () => {
+    const input = Array.from({ length: 20 }, (_, i) => trade(i, 1, { status: "breakeven" }));
+    expect(performanceTrends(input)).toMatchObject({
+      overallWinRate: 0,
+      largestWin: null,
+      points: [{ sequence: 20, winRate: 0, avgNetPnl: 1 }],
+    });
+  });
+  it("does not borrow trades outside account, date, annotation, and timezone scope", () => {
+    const input = Array.from({ length: 25 }, (_, i) =>
+      trade(i, 10, { annotations: { tags: ["setup"] } }),
+    );
+    input.push(trade(25, 999, { accountId: "b" }));
+    input.push(trade(26, 999));
+    input.push(
+      trade(27, 5, { closedAt: "2026-09-01T00:30:00Z", annotations: { tags: ["setup"] } }),
+    );
+    const filters = { accounts: "a", tag: "setup", from: "2026-08-01", to: "2026-08-31" };
+    const scoped = performanceTrends(
+      input.filter((t) => matchesFilters(t, filters, "America/New_York")),
+    );
+    expect(scoped.count).toBe(26);
+    expect(scoped.points.at(-1)?.avgNetPnl).toBe(9.75);
+    expect(performanceTrends(input.filter((t) => matchesFilters(t, filters, "UTC"))).count).toBe(
+      25,
+    );
+    expect(
+      performanceTrends(
+        input.filter((t) => matchesFilters(t, { ...filters, from: "2026-08-20" }, "UTC")),
+      ).points,
+    ).toEqual([]);
+  });
+});

--- a/apps/web/tests/theme.test.ts
+++ b/apps/web/tests/theme.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { runInNewContext } from "node:vm";
+import { THEME_INIT_SCRIPT, THEME_KEY, themePreference } from "../src/lib/theme";
+
+describe("journal appearance", () => {
+  it("defaults to dark and accepts only explicit light or dark choices", () => {
+    expect(themePreference(null)).toBe("dark");
+    expect(themePreference("system")).toBe("dark");
+    expect(themePreference("invalid")).toBe("dark");
+    expect(themePreference("dark")).toBe("dark");
+    expect(themePreference("light")).toBe("light");
+  });
+  it.each([null, "dark", "light", "invalid"])("applies %s before hydration", (saved) => {
+    const calls: unknown[] = [];
+    runInNewContext(THEME_INIT_SCRIPT, {
+      localStorage: {
+        getItem: (key: string) => {
+          expect(key).toBe(THEME_KEY);
+          return saved;
+        },
+      },
+      document: {
+        documentElement: { classList: { toggle: (...args: unknown[]) => calls.push(args) } },
+      },
+    });
+    expect(calls).toEqual([["dark", themePreference(saved) === "dark"]]);
+  });
+  it("still renders dark when browser storage is blocked", () => {
+    let dark = false;
+    runInNewContext(THEME_INIT_SCRIPT, {
+      localStorage: {
+        getItem: () => {
+          throw new Error("blocked");
+        },
+      },
+      document: {
+        documentElement: {
+          classList: {
+            toggle: (_: string, value: boolean) => {
+              dark = value;
+            },
+          },
+        },
+      },
+    });
+    expect(dark).toBe(true);
+  });
+});

--- a/apps/web/tests/trade-explorer.test.ts
+++ b/apps/web/tests/trade-explorer.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { matchesFilters, type AnnotatedTrade } from "@luxalgo/journal-core";
+import { clockLabel, plotTradePoints, tradeExplorerPoints } from "../src/lib/trade-explorer";
+
+const trade = (patch: Partial<AnnotatedTrade> = {}): AnnotatedTrade => ({
+  key: "a|AAPL|long|2026-09-01T00:30:00Z",
+  accountId: "a",
+  symbol: "AAPL",
+  direction: "long",
+  status: "win",
+  openedAt: "2026-09-01T00:30:00Z",
+  closedAt: "2026-09-01T01:00:30Z",
+  quantity: 10,
+  openQuantity: 0,
+  avgEntry: 100,
+  avgExit: 110,
+  netPnl: 96,
+  grossPnl: 100,
+  fees: 4,
+  executionCount: 2,
+  executionIds: [],
+  exits: [],
+  annotations: { stopLoss: 98, tags: ["setup"] },
+  ...patch,
+});
+
+describe("trade explorer", () => {
+  it("plots one net-of-fees observation per closed trade with exact elapsed minutes", () => {
+    const rows = tradeExplorerPoints(
+      [trade(), trade({ key: "open", status: "open", closedAt: undefined })],
+      "UTC",
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      durationMinutes: 30.5,
+      entryMinute: 30,
+      netPnl: 96,
+      realizedR: 4.8,
+    });
+    expect(plotTradePoints(rows, "durationMinutes", "netPnl")[0]).toMatchObject({ x: 30.5, y: 96 });
+  });
+  it("uses local entry time while elapsed duration remains timezone independent", () => {
+    expect(tradeExplorerPoints([trade()], "America/New_York")[0]).toMatchObject({
+      durationMinutes: 30.5,
+      entryMinute: 20 * 60 + 30,
+    });
+    const dst = trade({ openedAt: "2026-11-01T05:30:00Z", closedAt: "2026-11-01T06:30:00Z" });
+    expect(tradeExplorerPoints([dst], "America/New_York")[0]).toMatchObject({
+      durationMinutes: 60,
+      entryMinute: 90,
+    });
+    expect(clockLabel(1230)).toBe("20:30");
+    expect(clockLabel(0)).toBe("00:00");
+    expect(clockLabel(1440)).toBe("24:00");
+  });
+  it("preserves zero outcomes and excludes missing risk only from R views", () => {
+    const rows = tradeExplorerPoints(
+      [
+        trade({ key: "no-risk", annotations: {} }),
+        trade({ key: "zero", netPnl: 0, status: "breakeven" }),
+      ],
+      "UTC",
+    );
+    expect(plotTradePoints(rows, "durationMinutes", "netPnl")).toHaveLength(2);
+    expect(plotTradePoints(rows, "entryMinute", "realizedR")).toMatchObject([
+      { key: "zero", y: 0 },
+    ]);
+    expect(tradeExplorerPoints([trade({ assetClass: "futures" })], "UTC")[0]!.realizedR).toBeNull();
+    expect(
+      tradeExplorerPoints([trade({ assetClass: "futures", contractMultiplier: 2 })], "UTC")[0]!
+        .realizedR,
+    ).toBe(2.4);
+  });
+  it("excludes invalid axis inputs without fabricating zeroes", () => {
+    const rows = tradeExplorerPoints(
+      [
+        trade({ key: "reverse", closedAt: "2026-08-31T00:00:00Z" }),
+        trade({ key: "bad-open", openedAt: "invalid" }),
+        trade({ key: "bad-close", closedAt: "invalid" }),
+        trade({ key: "infinite", netPnl: Infinity }),
+        trade({ key: "zero-duration", closedAt: "2026-09-01T00:30:00Z" }),
+      ],
+      "UTC",
+    );
+    expect(plotTradePoints(rows, "durationMinutes", "netPnl").map((p) => p.key)).toEqual([
+      "zero-duration",
+    ]);
+    expect(plotTradePoints(rows, "entryMinute", "netPnl").map((p) => p.key)).toEqual([
+      "zero-duration",
+      "reverse",
+    ]);
+  });
+  it("preserves account/date/tag filtering and does not mutate source trades", () => {
+    const input = [
+      trade(),
+      trade({ key: "other", accountId: "b" }),
+      trade({ key: "untagged", annotations: {} }),
+    ];
+    const before = structuredClone(input);
+    const filters = { accounts: "a", tag: "setup", from: "2026-08-31", to: "2026-08-31" };
+    const rows = tradeExplorerPoints(
+      input.filter((t) => matchesFilters(t, filters, "America/New_York")),
+      "America/New_York",
+    );
+    expect(rows).toHaveLength(1);
+    expect(input).toEqual(before);
+    expect(
+      tradeExplorerPoints(
+        input.filter((t) => matchesFilters(t, filters, "UTC")),
+        "UTC",
+      ),
+    ).toEqual([]);
+    expect(plotTradePoints([], "durationMinutes", "netPnl")).toEqual([]);
+  });
+});

--- a/docs/calendar-insights.md
+++ b/docs/calendar-insights.md
@@ -1,0 +1,48 @@
+# Calendar performance insights
+
+Source: `GET /api/calendar` uses the existing `queryTrades` predicate, `dailyStats`,
+and `calendarMonthFromDays`. No generated or demonstration values are added.
+The Calendar UI continues to show the full month; analytics use the intersection
+of that month and the global date range, accounts, and remaining filters. The
+server's journal timezone determines closing dates and the initial visible month.
+
+## Definitions
+
+- Net P&L: sum of completed round trips after fees. Open positions are excluded.
+- Average daily P&L: net total / days with closed trades, including zero-net days.
+- Trade win rate: winning trades / all closed trades, including configured break-even trades.
+- Best/worst day: maximum/minimum daily net P&L. Ties select the earliest date;
+  one-day selections have the same best and worst day. Best need not be positive.
+- Green/red day averages: mean strictly positive/negative daily totals respectively.
+  An absent group is unavailable, not zero.
+- Day consistency: positive-net days / all trading days. This is a descriptive
+  profitable-day rate, not the dashboard's Edge Score or a predictive measure.
+- Most profitable weekday: largest strictly positive total by **closing** weekday.
+  Zero-trade weekdays never win. No positive totals means no profitable weekday.
+
+## Chart map and interaction
+
+| View | Question and encoding | Sufficiency and interaction |
+| --- | --- | --- |
+| Daily performance | How do daily results vary? Zero-anchored signed bars, after-fee P&L by closing date. | At least two trading days; one day gets an explicit summary. A dashed five-trading-day rolling mean appears only with at least eight observed trading days; no pre-window values or invented days. Bar selection opens matching trades; a semantic table supplies equivalent keyboard links and exact values. |
+| Weekday performance | Which closing weekdays contribute net gains/losses? Diverging bars on a shared symmetric zero scale and signed values. | All seven weekday positions, no-data rows disabled. Each weekday expands its actual closing dates; date links open matching trades. Small samples are explicitly flagged rather than extending beyond the selected scope. |
+
+Existing product P&L green/red is the intentional domain exception to a neutral
+palette. Signs, zero lines, direct labels, and position also encode polarity.
+Use shared theme, tooltip, card, privacy, chart-frame, and reduced-motion behavior.
+
+Drill-downs preserve filters and fix `range=custom`, `from`, and `to` to the
+visible scope or chosen closing day. Existing `weekdays` means entry weekday, so
+it is never replaced with a closing-weekday value. No new global filter semantics.
+
+Monetary results are shown only for a single account currency. Mixed-currency
+selections retain trade counts/rates but hide combined monetary results, green-day
+counts, and heatmap magnitudes, with an explanatory prompt; no FX rate is assumed.
+
+## QA
+
+Pure tests cover reconciliation, fee inclusion, averages/denominators, flat and
+one-sided data, ties, empty views, rolling windows, leap months, filter intersections,
+timezone boundaries, open positions, account isolation, and drill-down preservation.
+Browser checks should cover month navigation, filtering, inspection links, privacy,
+loading/failure/empty states, both themes, mobile widths, and reduced motion.

--- a/docs/calendar-insights.md
+++ b/docs/calendar-insights.md
@@ -22,10 +22,10 @@ server's journal timezone determines closing dates and the initial visible month
 
 ## Chart map and interaction
 
-| View | Question and encoding | Sufficiency and interaction |
-| --- | --- | --- |
-| Daily performance | How do daily results vary? Zero-anchored signed bars, after-fee P&L by closing date. | At least two trading days; one day gets an explicit summary. A dashed five-trading-day rolling mean appears only with at least eight observed trading days; no pre-window values or invented days. Bar selection opens matching trades; a semantic table supplies equivalent keyboard links and exact values. |
-| Weekday performance | Which closing weekdays contribute net gains/losses? Diverging bars on a shared symmetric zero scale and signed values. | All seven weekday positions, no-data rows disabled. Each weekday expands its actual closing dates; date links open matching trades. Small samples are explicitly flagged rather than extending beyond the selected scope. |
+| View                | Question and encoding                                                                                                  | Sufficiency and interaction                                                                                                                                                                                                                                                                                   |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Daily performance   | How do daily results vary? Zero-anchored signed bars, after-fee P&L by closing date.                                   | At least two trading days; one day gets an explicit summary. A dashed five-trading-day rolling mean appears only with at least eight observed trading days; no pre-window values or invented days. Bar selection opens matching trades; a semantic table supplies equivalent keyboard links and exact values. |
+| Weekday performance | Which closing weekdays contribute net gains/losses? Diverging bars on a shared symmetric zero scale and signed values. | All seven weekday positions, no-data rows disabled. Each weekday expands its actual closing dates; date links open matching trades. Small samples are explicitly flagged rather than extending beyond the selected scope.                                                                                     |
 
 Existing product P&L green/red is the intentional domain exception to a neutral
 palette. Signs, zero lines, direct labels, and position also encode polarity.

--- a/docs/performance-trends.md
+++ b/docs/performance-trends.md
@@ -1,0 +1,19 @@
+# Performance trends
+
+Reports → Performance trends adds two ordered-trade trends and an individual-trade extreme comparison, without duplicating the dashboard's aggregate cards.
+
+Source: filtered journal round trips, closed trades only, in closing-timestamp order with trade key breaking ties. The existing query layer owns account, date, annotation, and timezone filtering. No trades outside the selection are borrowed to complete windows. Dates are displayed in the journal timezone.
+
+## Definitions and chart map
+
+- Rolling win rate: wins / 20 closed trades, including losses and breakevens in the denominator. Honors the journal's configured outcome classification.
+- Rolling average net P&L: sum of net P&L / 20 closed trades, after recorded fees.
+- Each point is the full window ending at the indicated trade. X is closed-trade sequence, not elapsed time. The first point is trade 20. Overlapping windows are descriptive, not independent observations or forecasts.
+- Reference: the same measure across all closed trades in the active selection; not a target or a previous-period comparison.
+- Largest winner and loser: maximum net P&L among classified wins and minimum among classified losses. Earliest closed trade wins ties. Missing side is unavailable, not zero. Detail links open the actual trade.
+
+Native application Recharts line charts use a single product blue and a dashed neutral selected-period reference. Win rate uses 0–100%; net P&L includes zero. Signed P&L labels retain existing journal green/red semantics. Both plots have exact-value, keyboard-accessible table equivalents. No new rendering dependency.
+
+Sparse fallback: under 20 trades shows progress toward a full window; 20–26 trades shows the latest full-window values without an underpowered line chart. At least 8 complete windows (27 trades) enables lines. Empty results have no fabricated values. Mixed currencies retain win rate but hide monetary comparisons without FX conversion. Monetary values honor privacy mode.
+
+The report and chart code are lazy-loaded. Shared chart entrance behavior respects reduced motion. Responsive cards stack on small viewports; exact-value rows scroll within their own container. Loading and request failure/retry states use existing application primitives.

--- a/docs/trade-explorer.md
+++ b/docs/trade-explorer.md
@@ -1,0 +1,15 @@
+# Trade explorer
+
+Reports → Trade explorer: how do individual closed-trade outcomes vary with holding time or entry time? Existing grouped reports conceal individual dispersion; this view exposes it without asserting causality or an optimal holding time.
+
+Native Recharts scatter in the existing application, lazy-loaded. One observation per filtered closed round trip, no aggregates or interpolation. Default x = elapsed minutes from first entry to final close; alternate x = opening clock minute in the journal timezone. Default y = net P&L after recorded fees; alternate y = realized R from the core risk calculation (net P&L / stop-based planned risk, with required derivative multipliers). Entry time is circular: midnight neighbors are at opposite ends. No regression is inferred.
+
+Data: existing account/date/annotation filters via queryTrades. Invalid timestamps/duration, nonfinite outcomes and missing/invalid risk are excluded only when required by the selected axes. Report plotted and excluded counts. No outside-selection history is fetched to inflate a sparse sample. Fewer than 8 comparable trades uses the exact-values table instead of an underpowered scatter; 8–19 points has a small-sample notice.
+
+Linear axes include zero; time-of-day axis spans 00:00–24:00. All points are constant-size circles, as requested. Positive net P&L = green, negative = red, zero = neutral. Position relative to zero, signed tooltip values and the exact-value table provide non-color cues. Classification here is the numerical P&L sign, explicitly distinct from configurable breakeven outcomes. Quiet grid, bounded tooltip, matching light/dark tokens, reduced-motion-aware shared chart frame. No synthetic market prices.
+
+Reports content stays immediately visible: cards, text, tables, controls, axes and grids do not animate. Only plotted lines reveal and scatter circles fade in over 850ms when mounted. Overview retains its existing graph animation. No transforms, delays or interaction locks. All graph entrances are disabled with reduced motion.
+
+Interactions: click/tap a point to inspect it, then follow its existing trade detail link. Paginated semantic table gives all plotted trades and direct keyboard-accessible links, including coincident points. Axis controls are labeled native app selects. Mixed currencies block currency-denominated plots and amounts; unitless R can still be inspected. Privacy mode masks monetary values in axes, tooltips, selected-trade panels and tables.
+
+QA: calculation/axis eligibility and timezone unit tests; API reconciled against filtered trade list; inspect both themes and mobile widths; exercise selection, axes, sparse/empty/error/retry states, privacy and reduced motion. Existing Reports tabs remain unchanged.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev": "pnpm --filter web dev",
     "build": "pnpm --filter web build",
     "start": "pnpm --filter web start",
+    "preview": "pnpm build && pnpm start",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "pnpm -r --parallel typecheck",

--- a/packages/core/src/equity.ts
+++ b/packages/core/src/equity.ts
@@ -89,6 +89,28 @@ export interface DrawdownStats {
   peak: number;
 }
 
+export interface RelativeDrawdownPoint {
+  t: string;
+  /** Fall from the running equity peak as a positive fraction. */
+  drawdownPct: number | null;
+}
+
+/** Point-in-time relative drawdown for an underwater chart. */
+export const relativeDrawdownCurve = (
+  curve: EquityPoint[],
+  initialBalance = 0,
+): RelativeDrawdownPoint[] => {
+  let peak = 0;
+  return curve.map((point) => {
+    if (point.cumNetPnl > peak) peak = point.cumNetPnl;
+    const base = initialBalance + peak;
+    return {
+      t: point.t,
+      drawdownPct: base > 0 ? (peak - point.cumNetPnl) / base : null,
+    };
+  });
+};
+
 /** Drawdown over any cumulative curve. `initialBalance` anchors the percentage. */
 export const drawdown = (curve: EquityPoint[], initialBalance = 0): DrawdownStats => {
   let peak = 0;

--- a/packages/core/tests/metrics.test.ts
+++ b/packages/core/tests/metrics.test.ts
@@ -3,7 +3,13 @@ import { buildRoundTrips } from "../src/round-trips";
 import { computeMetrics, realizedR } from "../src/metrics";
 import { EDGE_SCORE_VERSION, computeEdgeScore } from "../src/edge-score";
 import { calendarMonth, byWeekday, byDuration } from "../src/aggregate";
-import { dailyStats, drawdown, equityCurve, intradayCurve } from "../src/equity";
+import {
+  dailyStats,
+  drawdown,
+  equityCurve,
+  intradayCurve,
+  relativeDrawdownCurve,
+} from "../src/equity";
 import { dayKeyOf } from "../src/time";
 import type { AnnotatedTrade } from "../src/types";
 import { fill } from "./helpers";
@@ -56,6 +62,12 @@ describe("performance metrics tell the trader the truth about their edge", () =>
     const dd = drawdown(curve, 1000);
     expect(dd.maxDrawdown).toBe(100);
     expect(dd.maxDrawdownPct).toBeCloseTo(100 / 1150, 6);
+  });
+
+  it("relative drawdown tracks every point below the running equity peak", () => {
+    const curve = equityCurve(sampleTrades());
+    const relative = relativeDrawdownCurve(curve, 1000);
+    expect(relative.map((point) => point.drawdownPct)).toEqual([0, 50 / 1100, 0, 100 / 1150]);
   });
 
   it("a profitable account with zero losing trades reports an infinite profit factor explicitly", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       react:
         specifier: ^19.1.0
         version: 19.2.8
+      react-day-picker:
+        specifier: ^9.14.0
+        version: 9.14.0(react@19.2.8)
       react-dom:
         specifier: ^19.1.0
         version: 19.2.8(react@19.2.8)
@@ -184,6 +187,9 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@date-fns/tz@1.5.0':
+    resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
+
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
     peerDependencies:
@@ -206,16 +212,34 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.28.2':
     resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.28.2':
     resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.2':
@@ -224,16 +248,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.28.2':
     resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.28.2':
     resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.2':
@@ -242,10 +284,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.28.2':
     resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.2':
@@ -254,10 +308,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.28.2':
     resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.2':
@@ -266,10 +332,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.28.2':
     resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.2':
@@ -278,10 +356,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.28.2':
     resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.2':
@@ -290,10 +380,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.28.2':
     resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.2':
@@ -302,16 +404,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.28.2':
     resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.28.2':
     resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.2':
@@ -320,10 +440,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.28.2':
     resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.2':
@@ -332,11 +464,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.28.2':
     resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.28.2':
     resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
@@ -344,16 +488,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.28.2':
     resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.28.2':
     resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.28.2':
@@ -1011,6 +1173,10 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
+  '@tabby_ai/hijri-converter@1.0.5':
+    resolution: {integrity: sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==}
+    engines: {node: '>=16.0.0'}
+
   '@tailwindcss/node@4.3.3':
     resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
 
@@ -1334,7 +1500,7 @@ packages:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
-      esbuild: ^0.28.1
+      esbuild: '>=0.18'
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -1443,6 +1609,12 @@ packages:
   d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
     engines: {node: '>=12'}
+
+  date-fns-jalali@4.1.0-0:
+    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
+
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1592,6 +1764,11 @@ packages:
 
   es-toolkit@1.51.0:
     resolution: {integrity: sha512-zC2lQGkM7QX+Gm6iM3+WIdZJzthsEd14LvRNJneSO2hzyz/zNBENR8+YXWo1cKxgPBtV6ksPYHELbcwBRzmdCw==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.28.2:
     resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
@@ -2055,6 +2232,10 @@ packages:
       yaml:
         optional: true
 
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2082,6 +2263,12 @@ packages:
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
+
+  react-day-picker@9.14.0:
+    resolution: {integrity: sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=16.8.0'
 
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
@@ -2554,6 +2741,8 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@date-fns/tz@1.5.0': {}
+
   '@dnd-kit/accessibility@3.1.1(react@19.2.8)':
     dependencies:
       react: 19.2.8
@@ -2579,79 +2768,157 @@ snapshots:
       react: 19.2.8
       tslib: 2.8.1
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm64@0.28.2':
     optional: true
 
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
   '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/android-x64@0.28.2':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-x64@0.28.2':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
   '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-arm@0.28.2':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
   '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-loong64@0.28.2':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
   '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
   '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-s390x@0.28.2':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
   '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
   '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.28.2':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
   '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-x64@0.28.2':
@@ -3236,6 +3503,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@tabby_ai/hijri-converter@1.0.5': {}
+
   '@tailwindcss/node@4.3.3':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -3585,9 +3854,9 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bundle-require@5.1.0(esbuild@0.28.2):
+  bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
-      esbuild: 0.28.2
+      esbuild: 0.27.7
       load-tsconfig: 0.2.5
 
   cac@6.7.14: {}
@@ -3676,6 +3945,10 @@ snapshots:
 
   d3-timer@3.0.1: {}
 
+  date-fns-jalali@4.1.0-0: {}
+
+  date-fns@4.4.0: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -3726,6 +3999,35 @@ snapshots:
   es-module-lexer@1.7.0: {}
 
   es-toolkit@1.51.0: {}
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   esbuild@0.28.2:
     optionalDependencies:
@@ -4299,7 +4601,7 @@ snapshots:
       '@next/env': 15.5.23
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001809
-      postcss: 8.5.26
+      postcss: 8.4.31
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       styled-jsx: 5.1.6(react@19.2.8)
@@ -4368,6 +4670,12 @@ snapshots:
       jiti: 2.7.0
       postcss: 8.5.26
 
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postcss@8.5.26:
     dependencies:
       nanoid: 3.3.18
@@ -4406,6 +4714,14 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+
+  react-day-picker@9.14.0(react@19.2.8):
+    dependencies:
+      '@date-fns/tz': 1.5.0
+      '@tabby_ai/hijri-converter': 1.0.5
+      date-fns: 4.4.0
+      date-fns-jalali: 4.1.0-0
+      react: 19.2.8
 
   react-dom@19.2.8(react@19.2.8):
     dependencies:
@@ -4700,12 +5016,12 @@ snapshots:
 
   tsup@8.5.1(jiti@2.7.0)(postcss@8.5.26)(typescript@5.9.3):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.28.2)
+      bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.28.2
+      esbuild: 0.27.7
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1


### PR DESCRIPTION
## Summary

Polishes the journal interface, improves responsiveness, and adds useful performance insights based on existing journal data.

### Dashboard and navigation

- Rebalance all 16 dashboard cards, reduce empty space, and improve responsive sizing.
- Add relative drawdown bars beneath cumulative P&L and contain Edge Score chart labels and hover elements.
- Reduce drag-and-drop jitter near screen edges.
- Add a smoothly collapsible sidebar and saved light/dark themes; dark remains the default.

### Controls and feedback

- Refine Filters, date pickers, checkboxes, dropdowns, and notebook template menus.
- Standardise hover help and match calendar hover outlines to daily performance.
- Add subtle chart entrances and popup fades, respecting reduced motion. Reports animate chart data rather than entire sections.
- Replace raw AI errors and browser alerts with actionable inline notices, setup links, and retry states.

### Insights and performance

- Add Calendar summaries, best/worst days, daily averages, consistency, and daily/weekday trends with trade drill-downs.
- Add rolling 20-trade win-rate/P&L trends and largest individual winning/losing trades to Reports.
- Add an interactive Trade explorer scatter plot with circular points, selectable axes, and an accessible trade table.
- Apply account, filter, and timezone context, with insufficient-data and mixed-currency safeguards.
- Remove navigation-blocking waits, defer heavy charts, limit the initial Daily Journal to 50 days with older days available on demand, and improve loading/retry states.
- Document an optimized production-preview workflow for local use.

## Verification

- `pnpm test`: 191 tests passed across 28 files.
- `pnpm typecheck`: passed.
- Production build passed during implementation.
- Browser checks covered key interactions, responsive layouts, light/dark themes, keyboard controls, privacy, and reduced motion.

## Notes

- Targets `dev`; no merge is performed by this PR.
- Summary report, visual gallery, screenshots, and local demo CSV are not included.
- Larger journals and slower devices remain useful follow-up performance checks; no universal speedup is claimed.
